### PR TITLE
Thread safe context

### DIFF
--- a/src/pynaviz/video/video_handling.py
+++ b/src/pynaviz/video/video_handling.py
@@ -163,6 +163,10 @@ class VideoHandler:
     @contextmanager
     def _set_get_from_index(self, value):
         """Context manager for setting the shallow copy flag in a thread safe way."""
+        # safe getattr is needed because the local variable is initialized
+        # with every thread, and a thread won't have `get_from_index` since
+        # in the main thread it is defined at __init__
+        # which is not called by the thread.
         old_value = getattr(self._thread_local, "get_from_index", False)
         self._thread_local.get_from_index = value
         try:


### PR DESCRIPTION
The `VideoHandler` class had currently a context manager that might have been thread unsafe. 

Currently, each video handler instance is defined in its separate process/thread, and that doesn't cause any race conditions, but in the future, it might.

With this change, the flag `get_from_index` is stored in a thread specific variable set with [`threading.local`](https://docs.python.org/3/library/threading.html#thread-local-data). This will prevent future race conditions in changing the context.