### PR TITLE
Fix timer stop start

### DIFF
--- a/src/pynaviz/controller.py
+++ b/src/pynaviz/controller.py
@@ -430,6 +430,7 @@ class GetController(CustomController):
         new_t = None
         if "cam_state" in event.kwargs:
             new_t = event.kwargs["cam_state"]["position"][0]
+            self._current_time = new_t
         elif "current_time" in event.kwargs:
             self._current_time = event.kwargs["current_time"]
             index = np.searchsorted(self.data.index, self._current_time, side="right") - 1

--- a/src/pynaviz/qt/mainwindow.py
+++ b/src/pynaviz/qt/mainwindow.py
@@ -249,7 +249,6 @@ class MainDock(QDockWidget):
         self.playing = False
         self.timer = QTimer()
         self.timer.timeout.connect(self._play)
-        self.timer.start(25) # 40 FPS
 
         shortcut = QShortcut(QKeySequence("Space"), self)
         shortcut.activated.connect(self._toggle_play)
@@ -265,15 +264,16 @@ class MainDock(QDockWidget):
         self.playing = not self.playing
         if self.playing:
             # Switch to pause icon
+            self.timer.start(25)  # 40 FPS
             self.playPauseBtn.setIcon(QIcon.fromTheme("media-playback-pause"))
         else:
             # Switch to play icon
+            self.timer.stop()  # 40 FPS
             self.playPauseBtn.setIcon(QIcon.fromTheme("media-playback-start"))
 
     def _play(self, delta=0.025):
-        if self.playing:
-            self.ctrl_group.advance(delta=delta)
-            self._update_time_label(self.ctrl_group.current_time)
+        self.ctrl_group.advance(delta=delta)
+        self._update_time_label(self.ctrl_group.current_time)
 
     def _on_unit_changed(self):
         """When user changes units, update the spinbox display"""

--- a/src/pynaviz/qt/mainwindow.py
+++ b/src/pynaviz/qt/mainwindow.py
@@ -268,7 +268,7 @@ class MainDock(QDockWidget):
             self.playPauseBtn.setIcon(QIcon.fromTheme("media-playback-pause"))
         else:
             # Switch to play icon
-            self.timer.stop()  # 40 FPS
+            self.timer.stop()
             self.playPauseBtn.setIcon(QIcon.fromTheme("media-playback-start"))
 
     def _play(self, delta=0.025):


### PR DESCRIPTION
Fixed a bug encountered with the following sequence of actions:

1. open a mainwindow
2. add a tsdtensor
3. add a tsdframe
4. play
5. stop
6. play again (instead of starting from 0 it would start from wherever it was at the stop time.)


In the process I simplified the play timer logic, stopping the timer at stop and restarting it at play.