### PR TITLE
File menu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         run: python -m pip install --upgrade pip nox
 
       - name: Cache nox environments
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .nox
           key: nox-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,29 +47,27 @@ jobs:
             libxkbcommon-x11-0 \
             libglib2.0-0 \
             mesa-vulkan-drivers
+          
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools
-          python -m pip install ".[dev]"
-      - name: Generate video and audio samples
-        run: |
-          python tests/generate_numbered_video.py
-          python tests/generate_noise_audio.py
-      - name: Generate Screenshots
-#        env:
-#          PYTHONPATH: ${{ github.workspace }}
-        run: |
-          python tests/generate_screenshots.py --type all --path tests/screenshots
-      - name: Run nox
-        run: |
-          nox --no-venv -s linters
-      - name: Test examples
+      - name: Install nox
+        run: python -m pip install --upgrade pip nox
+
+      - name: Cache nox environments
+        uses: actions/cache@v3
+        with:
+          path: .nox
+          key: nox-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            nox-${{ runner.os }}-py${{ matrix.python-version }}-
+
+      - name: Run linters
+        run: nox -s linters
+
+      - name: Run tests
         env:
           PYGFX_EXPECT_LAVAPIPE: true
           QT_QPA_PLATFORM: offscreen
-        run: |
-          WGPU_FORCE_OFFSCREEN=1 pytest -v tests/
+        run: nox -s tests
 
   check:
     if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,12 @@ jobs:
             libxcb-xinerama0 \
             libxkbcommon-x11-0 \
             libglib2.0-0 \
-            mesa-vulkan-drivers
+            mesa-vulkan-drivers \
+            libdbus-1-3 \
+            libxcb-cursor0 \
+            libxcb-randr0 \
+            x11-utils \
+            xvfb
 
       - name: Install nox
         run: python -m pip install --upgrade pip nox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,6 @@ jobs:
         run: nox -s linters
 
       - name: Run tests
-        env:
-          PYGFX_EXPECT_LAVAPIPE: true
-          QT_QPA_PLATFORM: offscreen
         run: nox -s tests
 
   check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,6 @@ jobs:
             libxkbcommon-x11-0 \
             libglib2.0-0 \
             mesa-vulkan-drivers
-          
 
       - name: Install nox
         run: python -m pip install --upgrade pip nox
@@ -75,5 +74,3 @@ jobs:
         uses: re-actors/alls-green@v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
-
-

--- a/docs/examples/example_head_direction.py
+++ b/docs/examples/example_head_direction.py
@@ -69,12 +69,12 @@ def main():
     frames.append(grab_window(win))
     durations.append(800)
 
-    list_widget = ctrl_dock.treeWidget
+    tree_widget = ctrl_dock.treeWidget
 
     # --- Add docks ---
-    add_dock_widget(list_widget, win, app, frames, durations, item_number=0) # units
-    add_dock_widget(list_widget, win, app, frames, durations, item_number=1) # manifold
-    add_dock_widget(list_widget, win, app, frames, durations, item_number=2) # video
+    add_dock_widget(tree_widget, win, app, frames, durations, item_number=0) # units
+    add_dock_widget(tree_widget, win, app, frames, durations, item_number=1) # manifold
+    add_dock_widget(tree_widget, win, app, frames, durations, item_number=2) # video
 
     # --- Resize and move the video dock ---
     move_and_resize_dock(win, app, frames, durations, move_offset=QPoint(500, 0), resize_width=400)

--- a/docs/examples/example_head_direction.py
+++ b/docs/examples/example_head_direction.py
@@ -69,7 +69,7 @@ def main():
     frames.append(grab_window(win))
     durations.append(800)
 
-    list_widget = ctrl_dock.listWidget
+    list_widget = ctrl_dock.treeWidget
 
     # --- Add docks ---
     add_dock_widget(list_widget, win, app, frames, durations, item_number=0) # units

--- a/docs/examples/example_lfp.py
+++ b/docs/examples/example_lfp.py
@@ -91,10 +91,10 @@ def main():
     frames.append(grab_window(win))
     durations.append(800)
 
-    list_widget = ctrl_dock.treeWidget
+    tree_widget = ctrl_dock.treeWidget
 
     # --- Add docks ---
-    add_dock_widget(list_widget, win, app, frames, durations, item_number=0) # eeg
+    add_dock_widget(tree_widget, win, app, frames, durations, item_number=0) # eeg
 
     # --- Apply metadata actions ---
     dock_widgets = win.findChildren(QDockWidget)

--- a/docs/examples/example_lfp.py
+++ b/docs/examples/example_lfp.py
@@ -91,7 +91,7 @@ def main():
     frames.append(grab_window(win))
     durations.append(800)
 
-    list_widget = ctrl_dock.listWidget
+    list_widget = ctrl_dock.treeWidget
 
     # --- Add docks ---
     add_dock_widget(list_widget, win, app, frames, durations, item_number=0) # eeg

--- a/docs/examples/example_trials.py
+++ b/docs/examples/example_trials.py
@@ -70,12 +70,12 @@ def main():
     frames.append(grab_window(win))
     durations.append(800)
 
-    list_widget = ctrl_dock.treeWidget
+    tree_widget = ctrl_dock.treeWidget
 
     # --- Add docks ---
-    add_dock_widget(list_widget, win, app, frames, durations, item_number=4)
-    add_dock_widget(list_widget, win, app, frames, durations, item_number=0)
-    add_dock_widget(list_widget, win, app, frames, durations, item_number=3)
+    add_dock_widget(tree_widget, win, app, frames, durations, item_number=4)
+    add_dock_widget(tree_widget, win, app, frames, durations, item_number=0)
+    add_dock_widget(tree_widget, win, app, frames, durations, item_number=3)
 
 
     # --- Resize and move the video dock ---

--- a/docs/examples/example_trials.py
+++ b/docs/examples/example_trials.py
@@ -70,7 +70,7 @@ def main():
     frames.append(grab_window(win))
     durations.append(800)
 
-    list_widget = ctrl_dock.listWidget
+    list_widget = ctrl_dock.treeWidget
 
     # --- Add docks ---
     add_dock_widget(list_widget, win, app, frames, durations, item_number=4)

--- a/docs/examples/example_videos.py
+++ b/docs/examples/example_videos.py
@@ -65,12 +65,12 @@ def main():
     frames.append(grab_window(win))
     durations.append(800)
 
-    list_widget = ctrl_dock.treeWidget
+    tree_widget = ctrl_dock.treeWidget
 
     # --- Add docks ---
-    add_dock_widget(list_widget, win, app, frames, durations, item_number=0)
-    add_dock_widget(list_widget, win, app, frames, durations, item_number=1)
-    add_dock_widget(list_widget, win, app, frames, durations, item_number=2)
+    add_dock_widget(tree_widget, win, app, frames, durations, item_number=0)
+    add_dock_widget(tree_widget, win, app, frames, durations, item_number=1)
+    add_dock_widget(tree_widget, win, app, frames, durations, item_number=2)
 
     # --- Resize and move the video dock ---
     move_and_resize_dock(win, app, frames, durations, move_offset=QPoint(500, 0), resize_width=500)

--- a/docs/examples/example_videos.py
+++ b/docs/examples/example_videos.py
@@ -65,7 +65,7 @@ def main():
     frames.append(grab_window(win))
     durations.append(800)
 
-    list_widget = ctrl_dock.listWidget
+    list_widget = ctrl_dock.treeWidget
 
     # --- Add docks ---
     add_dock_widget(list_widget, win, app, frames, durations, item_number=0)

--- a/docs/examples/utils.py
+++ b/docs/examples/utils.py
@@ -46,10 +46,47 @@ def click_on_item(list_widget, item_number, win, app, frames, durations):
     durations.append(800)
     return item
 
-def add_dock_widget(list_widget, win, app, frames, durations, item_number=0):
-    item = click_on_item(list_widget, item_number, win, app, frames, durations)
+def click_on_tree_item(tree_widget, item_index, win, app, frames, durations, column=0):
+    """Click on a tree widget item by index.
+
+    Parameters
+    ----------
+    tree_widget : QTreeWidget
+        The tree widget
+    item_index : int or tuple
+        If int, gets top-level item at that index.
+        If tuple like (0, 1), gets child item: topLevelItem(0).child(1)
+    column : int
+        Column to click on
+    """
+    # Get the item
+    if isinstance(item_index, int):
+        item = tree_widget.topLevelItem(item_index)
+    elif isinstance(item_index, tuple):
+        item = tree_widget.topLevelItem(item_index[0])
+        for child_idx in item_index[1:]:
+            item = item.child(child_idx)
+    else:
+        raise ValueError("item_index must be int or tuple")
+
+    if item is None:
+        raise ValueError(f"Item not found at index {item_index}")
+
+    # Get visual rectangle and click
+    rect = tree_widget.visualItemRect(item)
+    pos = rect.center()
+    QTest.mouseClick(tree_widget.viewport(),
+                     Qt.MouseButton.LeftButton,
+                     pos=pos)
+    QTest.qWait(1000)
+    frames.append(grab_window(win))
+    durations.append(800)
+    return item
+
+def add_dock_widget(tree_widget, win, app, frames, durations, item_number=0):
+    item = click_on_tree_item(tree_widget, item_number, win, app, frames, durations)
     app.processEvents()
-    list_widget.itemDoubleClicked.emit(item)
+    tree_widget.itemDoubleClicked.emit(item, 0)
     app.processEvents()
     QTest.qWait(1000)
     frames.append(grab_window(win))

--- a/main.py
+++ b/main.py
@@ -30,4 +30,4 @@ tsdtensor = nap.TsdTensor(t=np.arange(10000)/30, d=np.random.randn(10000, 10, 10
 iset = nap.IntervalSet(start=np.arange(0, 1000, 10), end=np.arange(5, 1005, 10))
 
 # layout_path = "layout.json"
-scope(globals(), layout_path = "layout.json")
+scope(globals())#, layout_path = "layout.json")

--- a/main.py
+++ b/main.py
@@ -30,4 +30,4 @@ tsdtensor = nap.TsdTensor(t=np.arange(10000)/30, d=np.random.randn(10000, 10, 10
 iset = nap.IntervalSet(start=np.arange(0, 1000, 10), end=np.arange(5, 1005, 10))
 
 
-scope(globals())
+scope(globals(), layout_path="layout.json")

--- a/main.py
+++ b/main.py
@@ -29,5 +29,5 @@ tsdtensor = nap.TsdTensor(t=np.arange(10000)/30, d=np.random.randn(10000, 10, 10
 
 iset = nap.IntervalSet(start=np.arange(0, 1000, 10), end=np.arange(5, 1005, 10))
 
-
-scope(globals(), layout_path="layout.json")
+# layout_path = "layout.json"
+scope(globals(), layout_path = "layout.json")

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,7 @@ def linters(session):
     session.run("ruff", "check", "src", "--ignore", "D")
     session.run("ruff", "check", "tests", "--ignore", "D")
 
-@nox.session(name="linters-fix")
+@nox.session(name="linters-fix", reuse_venv=True)
 def linters_fix(session):
     """Run linters and auto-fix issues"""
     session.install("-e", ".[dev]")

--- a/noxfile.py
+++ b/noxfile.py
@@ -71,6 +71,7 @@ def tests(session):
                 "PYGFX_WGPU_ADAPTER_NAME": "llvmpipe",
                 "PYGFX_EXPECT_LAVAPIPE": "true",
                 "DISPLAY": ":99.0",
+                "QT_QPA_PLATFORM": "offscreen",
             },
             external=True,  # xvfb-run is not a Python package
         )

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,17 +3,15 @@ import pathlib
 import nox
 
 
-@nox.session(name="linters", reuse_venv=True)
+@nox.session(name="linters")
 def linters(session):
     """Run linters"""
-    session.install("-e", ".[dev]")
     session.run("ruff", "check", "src", "--ignore", "D")
     session.run("ruff", "check", "tests", "--ignore", "D")
 
-@nox.session(name="linters-fix", reuse_venv=True)
+@nox.session(name="linters-fix")
 def linters_fix(session):
     """Run linters and auto-fix issues"""
-    session.install("-e", ".[dev]")
     session.run("ruff", "check", "src", "--ignore", "D", "--fix")
     session.run("ruff", "check", "tests", "--ignore", "D", "--fix")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,5 @@
 import pathlib
+import shutil
 
 import nox
 
@@ -58,9 +59,26 @@ def tests(session):
         # "--path", "tests/screenshots",
     )
     session.log("Run Tests...")
-    session.run(
-        "pytest",
-        env={
-            "WGPU_FORCE_OFFSCREEN": "1",
-        },
-    )
+
+    if shutil.which("xvfb-run"):
+        # CI environment - use xvfb
+        session.run(
+            "xvfb-run",
+            "-s", "-screen 0 1920x1200x24 +extension GLX",
+            "pytest", "-v", "tests/",
+            env={
+                "WGPU_FORCE_OFFSCREEN": "1",
+                "PYGFX_WGPU_ADAPTER_NAME": "llvmpipe",
+                "PYGFX_EXPECT_LAVAPIPE": "true",
+                "DISPLAY": ":99.0",
+            },
+            external=True,  # xvfb-run is not a Python package
+        )
+
+    else:
+        session.run(
+            "pytest",
+            env={
+                "WGPU_FORCE_OFFSCREEN": "1",
+            },
+        )

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,15 +3,17 @@ import pathlib
 import nox
 
 
-@nox.session(name="linters")
+@nox.session(name="linters", reuse_venv=True)
 def linters(session):
     """Run linters"""
+    session.install("-e", ".[dev]")
     session.run("ruff", "check", "src", "--ignore", "D")
     session.run("ruff", "check", "tests", "--ignore", "D")
 
-@nox.session(name="linters-fix")
+@nox.session(name="linters-fix", reuse_venv=True)
 def linters_fix(session):
     """Run linters and auto-fix issues"""
+    session.install("-e", ".[dev]")
     session.run("ruff", "check", "src", "--ignore", "D", "--fix")
     session.run("ruff", "check", "tests", "--ignore", "D", "--fix")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import shutil
 
@@ -60,7 +61,7 @@ def tests(session):
     )
     session.log("Run Tests...")
 
-    if shutil.which("xvfb-run"):
+    if os.getenv("CI") or os.getenv("GITHUB_ACTIONS"):
         # CI environment - use xvfb
         session.run(
             "xvfb-run",

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,15 +3,17 @@ import pathlib
 import nox
 
 
-@nox.session(name="linters")
+@nox.session(name="linters", reuse_venv=True)
 def linters(session):
     """Run linters"""
+    session.install("-e", ".[dev]")
     session.run("ruff", "check", "src", "--ignore", "D")
     session.run("ruff", "check", "tests", "--ignore", "D")
 
 @nox.session(name="linters-fix")
 def linters_fix(session):
     """Run linters and auto-fix issues"""
+    session.install("-e", ".[dev]")
     session.run("ruff", "check", "src", "--ignore", "D", "--fix")
     session.run("ruff", "check", "tests", "--ignore", "D", "--fix")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -71,7 +71,6 @@ def tests(session):
                 "PYGFX_WGPU_ADAPTER_NAME": "llvmpipe",
                 "PYGFX_EXPECT_LAVAPIPE": "true",
                 "DISPLAY": ":99.0",
-                "QT_QPA_PLATFORM": "offscreen",
             },
             external=True,  # xvfb-run is not a Python package
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,9 @@ dev = [
     "isort",
     "click",
     "imageio",
-    "pyqt6"
+    "pyqt6",
+    "fsspec",                      # Download file from OSF for testing
+    "aiohttp"
 ]
 docs = [
     "matplotlib",

--- a/src/pynaviz/qt/mainwindow.py
+++ b/src/pynaviz/qt/mainwindow.py
@@ -30,7 +30,6 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-from ..audiovideo import PlotVideo
 from ..audiovideo.video_plot import PlotBaseVideoTensor
 from ..controller_group import ControllerGroup
 from .widget_plot import (
@@ -765,7 +764,7 @@ class MainWindow(QMainWindow):
                 new_vars.update({name.stem + name.suffix: nap_obj_dict})
                 self._open_file_paths.add(name.as_posix())
             elif file_type == "Video":
-                new_vars.update({name.stem + name.suffix: PlotVideo(name)})
+                new_vars.update({name.stem + name.suffix: VideoWidget(name)})
                 self._open_file_paths.add(name.as_posix())
             else:
                 raise TypeError(f"Developer forgot to add file type `{file_type}` to the loader.")

--- a/src/pynaviz/qt/mainwindow.py
+++ b/src/pynaviz/qt/mainwindow.py
@@ -321,6 +321,8 @@ class MainDock(QDockWidget):
             parent = self.treeWidget
 
         # Get existing children
+        import pdb
+        pdb.set_trace()
         children = get_children_dict(parent)
 
         for key, value in item_dict.items():
@@ -735,8 +737,8 @@ class MainWindow(QMainWindow):
     def _load_multiple_files(self, filenames: list[str]):
         # find main dock
         dock = self.findChildren(MainDock)
-        if len(dock) != 1:
-            raise RuntimeError("MainWindow must have at most one dock.")
+        if len(dock) < 1:
+            raise RuntimeError("MainWindow should have at least one dock.")
         dock_widget = dock[0]
 
         # create the variable dict
@@ -747,7 +749,6 @@ class MainWindow(QMainWindow):
                     file_type = tp
                     break
             return file_type
-
         variables = dock_widget.variables
         new_vars = {}
         for name in filenames:

--- a/src/pynaviz/qt/mainwindow.py
+++ b/src/pynaviz/qt/mainwindow.py
@@ -765,7 +765,7 @@ class MainWindow(QMainWindow):
                 new_vars.update({name.stem + name.suffix: nap_obj_dict})
                 self._open_file_paths.add(name.as_posix())
             elif file_type == "Video":
-                new_vars.update({name: PlotVideo(name)})
+                new_vars.update({name.stem + name.suffix: PlotVideo(name)})
                 self._open_file_paths.add(name.as_posix())
             else:
                 raise TypeError(f"Developer forgot to add file type `{file_type}` to the loader.")

--- a/src/pynaviz/qt/mainwindow.py
+++ b/src/pynaviz/qt/mainwindow.py
@@ -592,7 +592,6 @@ class MainDock(QDockWidget):
                             "index": int(name.split("_")[-1]),
                             "name": name
                             }
-                    print(info)
                     docks.append(info)
                     order.append(int(name.split("_")[-1]))
             docks = [x for _, x in sorted(zip(order, docks))]
@@ -755,19 +754,17 @@ class MainWindow(QMainWindow):
                 print(f"File type {pathlib.Path(name).suffix} not supported. Skipping.")
             elif file_type in ["Pynapple"]:
                 new_vars.update({name.stem + name.suffix: nap.load_file(name)})
-                self._open_file_paths.add(name.as_posix())
             elif file_type in ["NWB"]:
                 data: nap.NWBFile = nap.load_file(name)
                 nap_obj_dict = {}
                 for key in data.keys():
                     nap_obj_dict[key] = NWBReference(nwb_file=data, key=key)
                 new_vars.update({name.stem + name.suffix: nap_obj_dict})
-                self._open_file_paths.add(name.as_posix())
             elif file_type == "Video":
                 new_vars.update({name.stem + name.suffix: VideoWidget(name)})
-                self._open_file_paths.add(name.as_posix())
             else:
                 raise TypeError(f"Developer forgot to add file type `{file_type}` to the loader.")
+            self._open_file_paths.add(name.as_posix())
         variables.update(new_vars)
         dock_widget._add_items_to_tree_widget(new_vars)
 

--- a/src/pynaviz/qt/mainwindow.py
+++ b/src/pynaviz/qt/mainwindow.py
@@ -752,6 +752,10 @@ class MainWindow(QMainWindow):
             file_type = get_type(name)
             if file_type is None:
                 print(f"File type {pathlib.Path(name).suffix} not supported. Skipping.")
+                continue
+            elif not name.exists():
+                print(f"File {name} does not exist. Skipping.")
+                continue
             elif file_type in ["Pynapple"]:
                 new_vars.update({name.stem + name.suffix: nap.load_file(name)})
             elif file_type in ["NWB"]:

--- a/src/pynaviz/qt/mainwindow.py
+++ b/src/pynaviz/qt/mainwindow.py
@@ -176,7 +176,7 @@ class MainDock(QDockWidget):
         container = QWidget()
         layout = QVBoxLayout(container)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(5)
+        layout.setSpacing(0)
 
         # Toolbar
         toolbar = QToolBar("Main Toolbar")

--- a/src/pynaviz/qt/mainwindow.py
+++ b/src/pynaviz/qt/mainwindow.py
@@ -577,6 +577,7 @@ class MainDock(QDockWidget):
                             "dtype": d.widget().plot.data.__class__.__name__,
                             "key_path": d.property("key_path"),
                             "index": int(name.split("_")[-1]),
+                            "open_file_list": list(self.gui._open_file_list),
                             "name": name
                             }
                     print(info)
@@ -728,15 +729,17 @@ class MainWindow(QMainWindow):
                 print(f"File type {pathlib.Path(name).suffix} not supported. Skipping.")
             elif file_type in ["Pynapple"]:
                 new_vars.update({name: nap.load_file(name)})
+                self._open_file_paths.add(name.as_posix())
             elif file_type in ["NWB"]:
                 data = nap.load_file(name)
                 nap_obj_dict = {}
                 for key in data.keys():
                     nap_obj_dict[key] = data[key]
                 new_vars.update({name.stem + name.suffix: nap_obj_dict})
-
+                self._open_file_paths.add(name.as_posix())
             elif file_type == "Video":
                 new_vars.update({name: PlotVideo(name)})
+                self._open_file_paths.add(name.as_posix())
             else:
                 raise TypeError(f"Developer forgot to add file type `{file_type}` to the loader.")
         variables.update(new_vars)

--- a/src/pynaviz/qt/mainwindow.py
+++ b/src/pynaviz/qt/mainwindow.py
@@ -756,7 +756,7 @@ class MainWindow(QMainWindow):
             if file_type is None:
                 print(f"File type {pathlib.Path(name).suffix} not supported. Skipping.")
             elif file_type in ["Pynapple"]:
-                new_vars.update({name: nap.load_file(name)})
+                new_vars.update({name.stem + name.suffix: nap.load_file(name)})
                 self._open_file_paths.add(name.as_posix())
             elif file_type in ["NWB"]:
                 data: nap.NWBFile = nap.load_file(name)

--- a/src/pynaviz/qt/mainwindow.py
+++ b/src/pynaviz/qt/mainwindow.py
@@ -321,8 +321,6 @@ class MainDock(QDockWidget):
             parent = self.treeWidget
 
         # Get existing children
-        import pdb
-        pdb.set_trace()
         children = get_children_dict(parent)
 
         for key, value in item_dict.items():

--- a/tests/_test_widget_menu.py
+++ b/tests/_test_widget_menu.py
@@ -3,9 +3,9 @@ from collections import OrderedDict
 from unittest.mock import MagicMock
 
 import pytest
-from pynaviz.qt.widget_list_selection import ChannelListModel
 from PyQt6.QtWidgets import QApplication, QComboBox, QDoubleSpinBox
 
+from pynaviz.qt.widget_list_selection import ChannelListModel
 from pynaviz.qt.widget_menu import ChannelList, DropdownDialog, MenuWidget, widget_factory
 
 

--- a/tests/_test_widget_menu.py
+++ b/tests/_test_widget_menu.py
@@ -3,9 +3,9 @@ from collections import OrderedDict
 from unittest.mock import MagicMock
 
 import pytest
+from pynaviz.qt.widget_list_selection import ChannelListModel
 from PyQt6.QtWidgets import QApplication, QComboBox, QDoubleSpinBox
 
-from pynaviz.qt.qt_item_models import ChannelListModel
 from pynaviz.qt.widget_menu import ChannelList, DropdownDialog, MenuWidget, widget_factory
 
 

--- a/tests/_test_widget_menu.py
+++ b/tests/_test_widget_menu.py
@@ -6,7 +6,6 @@ import pytest
 from PyQt6.QtWidgets import QApplication, QComboBox, QDoubleSpinBox
 
 from pynaviz.qt.widget_list_selection import ChannelListModel
-
 from pynaviz.qt.widget_menu import ChannelList, DropdownDialog, MenuWidget, widget_factory
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def dummy_tsdtensor():
     return config.TsdTensorConfig.get_data()
 
 @pytest.fixture
-def variables():
+def nap_var():
     return {
         "tsdframe": config.TsdFrameConfig.get_data(),
         "tsd": config.TsdConfig.get_data(),

--- a/tests/test_file_open.py
+++ b/tests/test_file_open.py
@@ -150,7 +150,7 @@ def test_load_files(shared_test_files, qapp):
             np.testing.assert_array_equal(var.plot.data.get(1), expected[name].get(1))
         # NWB are dicts.
         elif name == "dict":
-            for key, val in var.items():
+            for val in var.values():
                 assert isinstance(val, viz.qt.mainwindow.NWBReference)
                 assert val.nwb_file.path == expected[name].path
                 assert isinstance(val.nwb_file, expected[name].__class__)

--- a/tests/test_file_open.py
+++ b/tests/test_file_open.py
@@ -116,7 +116,7 @@ def shared_test_files(tmp_path_factory):
     return data_dir, video_file, nwb_file, expected_output
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def qapp():
     """Ensure QApplication exists."""
     if not QApplication.instance():

--- a/tests/test_file_open.py
+++ b/tests/test_file_open.py
@@ -1,12 +1,11 @@
 import pathlib
-import sys
 from unittest.mock import patch
 
 import fsspec
 import numpy as np
 import pynapple as nap
 import pytest
-from PyQt6.QtWidgets import QApplication, QDockWidget
+from PyQt6.QtWidgets import QDockWidget
 
 import pynaviz as viz
 

--- a/tests/test_file_open.py
+++ b/tests/test_file_open.py
@@ -1,12 +1,40 @@
+import pathlib
 import sys
 from unittest.mock import patch
 
+import fsspec
 import numpy as np
 import pynapple as nap
 import pytest
 from PyQt6.QtWidgets import QApplication, QDockWidget
 
 import pynaviz as viz
+
+
+def download_osf_file_chunked(url, output_path, chunk_size=8192):
+    """Download a file from OSF in chunks.
+
+    Parameters
+    ----------
+    url : str
+        The OSF download URL
+    output_path : str or Path
+        Where to save the downloaded file
+    chunk_size : int
+        Size of chunks to read at a time (in bytes)
+    """
+    output_path = pathlib.Path(output_path)
+    if output_path.exists():
+        return
+    output_path.parent.mkdir(exist_ok=True)
+    with fsspec.open(url, 'rb') as f_in:
+        with open(output_path, 'wb') as f_out:
+            while True:
+                chunk = f_in.read(chunk_size)
+                if not chunk:
+                    break
+                f_out.write(chunk)
+    print(f"Downloaded to {output_path}")
 
 
 def tree_widget_to_dict(tree_widget):
@@ -32,15 +60,16 @@ def tree_widget_to_dict(tree_widget):
         child_count = item.childCount()
         if child_count > 0:
             children = {}
+            flat_items = []
             for i in range(child_count):
                 child = item.child(i)
-                child_dict = process_item(child)
+                child_dict, child_flat = process_item(child)  # Unpack both return values
                 children.update(child_dict)
-            return {key: children}, []
+                flat_items.extend(child_flat)
+            return {key: children}, flat_items
         else:
-            # Leaf node - you might want to store the actual data here
-            # For now, just use the key
-            return {key: None}, [item]  # or return {key: item.data(0, Qt.ItemDataRole.UserRole)}
+            # Leaf node
+            return {key: None}, [item]
 
     result = {}
     flat_items = []
@@ -57,7 +86,8 @@ def tree_widget_to_dict(tree_widget):
 @pytest.fixture(scope="module")
 def shared_test_files(tmp_path_factory):
     """Create test files that persist across multiple tests."""
-    tmp_dir = tmp_path_factory.mktemp("data")
+    data_dir = tmp_path_factory.mktemp("data")
+    test_dir = pathlib.Path(__file__).parent
 
     # Create your files
     time = np.arange(10)
@@ -65,15 +95,25 @@ def shared_test_files(tmp_path_factory):
     tsd = nap.Tsd(time, data)
     tsd_frame = nap.TsdFrame(tsd.t, tsd.d[..., None])
     tsd_tensor = nap.TsdTensor(tsd_frame.t, tsd_frame.d[..., None])
-    tsd.save(tmp_dir / "test_tsd.npz")
-    tsd_frame.save(tmp_dir / "test_tsd_frame.npz")
-    tsd_tensor.save(tmp_dir / "test_tsd_tensor.npz")
+    tsd.save(data_dir / "test_tsd.npz")
+    tsd_frame.save(data_dir / "test_tsd_frame.npz")
+    tsd_tensor.save(data_dir / "test_tsd_tensor.npz")
+    video_file = test_dir / "test_video" / "numbered_video.mp4"
+    video = viz.audiovideo.VideoHandler(video_file)
+
+    # download nwb
+    url = "https://osf.io/download/y7zwd/"
+    nwb_file = test_dir / "test_nwb" / "nwb_file.nwb"
+    download_osf_file_chunked(url, nwb_file)
+    data = nap.load_file(nwb_file)
     expected_output = {
         "Tsd": tsd,
         "TsdFrame": tsd_frame,
         "TsdTensor": tsd_tensor,
+        "VideoWidget": video,
+        "dict": data,
     }
-    return tmp_dir, expected_output
+    return data_dir, video_file, nwb_file, expected_output
 
 
 @pytest.fixture(scope="module")
@@ -89,29 +129,42 @@ def qapp():
 
 def test_load_files(shared_test_files, qapp):
     """Test loading files directly via _load_multiple_files."""
-    path_dir, expected = shared_test_files
+    path_dir, video_path, nwb_file,  expected = shared_test_files
+    all_files = (*path_dir.iterdir(), video_path, nwb_file)
 
     main_window = viz.qt.mainwindow.MainWindow()
     dock = viz.qt.mainwindow.MainDock({}, main_window)
-    main_window._load_multiple_files(path_dir.iterdir())
+    main_window._load_multiple_files(all_files)
 
     for var in dock.variables.values():
         name = var.__class__.__name__
         if name in ["Tsd", "TsdFrame", "TsdTensor"]:
             np.testing.assert_array_equal(var.t, expected[name].t)
             np.testing.assert_array_equal(var.d, expected[name].d)
-        elif name in ["NWBReference"]:
+        elif name == "NWBReference":
             assert var.key == expected[name].key
             assert var.nwb_file.path == expected[name].nwb_file.path
+        elif name == "VideoWidget":
+            assert isinstance(var.plot.data, expected[name].__class__)
+            assert var.plot.data.file_path == expected[name].file_path
+            np.testing.assert_array_equal(var.plot.data.get(1), expected[name].get(1))
+        # NWB are dicts.
+        elif name == "dict":
+            for key, val in var.items():
+                assert isinstance(val, viz.qt.mainwindow.NWBReference)
+                assert val.nwb_file.path == expected[name].path
+                assert isinstance(val.nwb_file, expected[name].__class__)
+        else:
+            raise ValueError(f"Unknown variable: {name}")
 
 
 @patch('pynaviz.qt.mainwindow.QFileDialog.getOpenFileNames')
 def test_open_file_dialog(mock_dialog, shared_test_files, qapp):
     """Test the open_file method with mocked dialog."""
-    path_dir, expected = shared_test_files
+    path_dir, video_file, nwb_file, expected = shared_test_files
 
     # Get list of test files
-    test_files = [f.as_posix() for f in path_dir.iterdir()]
+    test_files = [f.as_posix() for f in path_dir.iterdir()] + [video_file, nwb_file]
 
     # Mock dialog returns (list of files, selected filter)
     mock_dialog.return_value = (test_files, "")
@@ -125,7 +178,21 @@ def test_open_file_dialog(mock_dialog, shared_test_files, qapp):
 
     # Verify files were loaded in the tree widget
     item_dict, flat_items = tree_widget_to_dict(dock.treeWidget)
-    assert  item_dict == {'test_tsd_frame.npz': None, 'test_tsd.npz': None, 'test_tsd_tensor.npz': None}
+    assert  item_dict == {
+        'numbered_video.mp4': None,
+        'nwb_file.nwb': {'epochs': None,
+                      'position_time_support': None,
+                      'rx': None,
+                      'ry': None,
+                      'rz': None,
+                      'units': None,
+                      'x': None,
+                      'y': None,
+                      'z': None},
+        'test_tsd.npz': None,
+        'test_tsd_frame.npz': None,
+        'test_tsd_tensor.npz': None
+    }
 
     # simulate dock creation
     for item in flat_items:
@@ -133,5 +200,6 @@ def test_open_file_dialog(mock_dialog, shared_test_files, qapp):
 
     children = main_window.findChildren(QDockWidget)
     children = [d.widget() for d in children if not isinstance(d, viz.qt.mainwindow.MainDock)]
-    assert len(children) == len(expected)
-    assert set(c.__class__.__name__ for c in children) == {"TsdWidget", "TsdFrameWidget", "TsdTensorWidget"}
+    assert len(children) == len(flat_items)
+    print(set(c.__class__.__name__ for c in children))
+    assert set(c.__class__.__name__ for c in children) == {"TsGroupWidget", "TsdWidget", "TsdFrameWidget", "TsdTensorWidget", "VideoWidget", "IntervalSetWidget"}

--- a/tests/test_file_open.py
+++ b/tests/test_file_open.py
@@ -116,18 +116,7 @@ def shared_test_files(tmp_path_factory):
     return data_dir, video_file, nwb_file, expected_output
 
 
-@pytest.fixture(scope="function")
-def qapp():
-    """Ensure QApplication exists."""
-    if not QApplication.instance():
-        app = QApplication(sys.argv)
-        app.setQuitOnLastWindowClosed(False)
-    else:
-        app = QApplication.instance()
-    return app
-
-
-def test_load_files(shared_test_files, qapp):
+def test_load_files(shared_test_files, qtbot):
     """Test loading files directly via _load_multiple_files."""
     path_dir, video_path, nwb_file,  expected = shared_test_files
     all_files = (*path_dir.iterdir(), video_path, nwb_file)
@@ -159,7 +148,7 @@ def test_load_files(shared_test_files, qapp):
 
 
 @patch('pynaviz.qt.mainwindow.QFileDialog.getOpenFileNames')
-def test_open_file_dialog(mock_dialog, shared_test_files, qapp):
+def test_open_file_dialog(mock_dialog, shared_test_files, qtbot):
     """Test the open_file method with mocked dialog."""
     path_dir, video_file, nwb_file, expected = shared_test_files
 

--- a/tests/test_file_open.py
+++ b/tests/test_file_open.py
@@ -1,12 +1,60 @@
-import pynaviz as viz
-import pytest
-import pynapple as nap
-import numpy as np
-from PyQt6.QtWidgets import QApplication
 import sys
+from unittest.mock import patch
+
+import numpy as np
+import pynapple as nap
+import pytest
+from PyQt6.QtWidgets import QApplication, QDockWidget
+
+import pynaviz as viz
 
 
-@pytest.fixture(scope="module")  # or scope="session"
+def tree_widget_to_dict(tree_widget):
+    """Extract all items from a QTreeWidget as a nested dictionary.
+
+    Parameters
+    ----------
+    tree_widget : QTreeWidget
+        The tree widget to extract items from.
+
+    Returns
+    -------
+    dict
+        Nested dictionary representing the tree structure.
+    """
+
+    def process_item(item):
+        """Recursively process a tree item and its children."""
+        # Get the item's text (assuming single column, adjust if needed)
+        key = item.text(0)
+
+        # If item has children, recurse
+        child_count = item.childCount()
+        if child_count > 0:
+            children = {}
+            for i in range(child_count):
+                child = item.child(i)
+                child_dict = process_item(child)
+                children.update(child_dict)
+            return {key: children}, []
+        else:
+            # Leaf node - you might want to store the actual data here
+            # For now, just use the key
+            return {key: None}, [item]  # or return {key: item.data(0, Qt.ItemDataRole.UserRole)}
+
+    result = {}
+    flat_items = []
+    # Process all top-level items
+    for i in range(tree_widget.topLevelItemCount()):
+        item = tree_widget.topLevelItem(i)
+        item_dict, flat_sub = process_item(item)
+        result.update(item_dict)
+        flat_items.extend(flat_sub)
+
+    return result, flat_items
+
+
+@pytest.fixture(scope="module")
 def shared_test_files(tmp_path_factory):
     """Create test files that persist across multiple tests."""
     tmp_dir = tmp_path_factory.mktemp("data")
@@ -19,7 +67,7 @@ def shared_test_files(tmp_path_factory):
     tsd_tensor = nap.TsdTensor(tsd_frame.t, tsd_frame.d[..., None])
     tsd.save(tmp_dir / "test_tsd.npz")
     tsd_frame.save(tmp_dir / "test_tsd_frame.npz")
-    tsd_tensor.save(tmp_dir / "test_tsd_frame.npz")
+    tsd_tensor.save(tmp_dir / "test_tsd_tensor.npz")
     expected_output = {
         "Tsd": tsd,
         "TsdFrame": tsd_frame,
@@ -27,19 +75,26 @@ def shared_test_files(tmp_path_factory):
     }
     return tmp_dir, expected_output
 
-def test_load_files(shared_test_files):
-    path_dir, expected = shared_test_files
-    # Set up Qt application (ensure it's headless for testing)
+
+@pytest.fixture(scope="module")
+def qapp():
+    """Ensure QApplication exists."""
     if not QApplication.instance():
         app = QApplication(sys.argv)
-        # Make headless for testing
         app.setQuitOnLastWindowClosed(False)
     else:
         app = QApplication.instance()
+    return app
+
+
+def test_load_files(shared_test_files, qapp):
+    """Test loading files directly via _load_multiple_files."""
+    path_dir, expected = shared_test_files
 
     main_window = viz.qt.mainwindow.MainWindow()
     dock = viz.qt.mainwindow.MainDock({}, main_window)
     main_window._load_multiple_files(path_dir.iterdir())
+
     for var in dock.variables.values():
         name = var.__class__.__name__
         if name in ["Tsd", "TsdFrame", "TsdTensor"]:
@@ -50,5 +105,33 @@ def test_load_files(shared_test_files):
             assert var.nwb_file.path == expected[name].nwb_file.path
 
 
+@patch('pynaviz.qt.mainwindow.QFileDialog.getOpenFileNames')
+def test_open_file_dialog(mock_dialog, shared_test_files, qapp):
+    """Test the open_file method with mocked dialog."""
+    path_dir, expected = shared_test_files
 
+    # Get list of test files
+    test_files = [f.as_posix() for f in path_dir.iterdir()]
 
+    # Mock dialog returns (list of files, selected filter)
+    mock_dialog.return_value = (test_files, "")
+
+    main_window = viz.qt.mainwindow.MainWindow()
+    dock = viz.qt.mainwindow.MainDock({}, main_window)
+    main_window.open_file()
+
+    # Verify dialog was called correctly
+    mock_dialog.assert_called_once()
+
+    # Verify files were loaded in the tree widget
+    item_dict, flat_items = tree_widget_to_dict(dock.treeWidget)
+    assert  item_dict == {'test_tsd_frame.npz': None, 'test_tsd.npz': None, 'test_tsd_tensor.npz': None}
+
+    # simulate dock creation
+    for item in flat_items:
+        dock.on_item_double_clicked(item, 0)
+
+    children = main_window.findChildren(QDockWidget)
+    children = [d.widget() for d in children if not isinstance(d, viz.qt.mainwindow.MainDock)]
+    assert len(children) == len(expected)
+    assert set(c.__class__.__name__ for c in children) == {"TsdWidget", "TsdFrameWidget", "TsdTensorWidget"}

--- a/tests/test_file_open.py
+++ b/tests/test_file_open.py
@@ -1,0 +1,54 @@
+import pynaviz as viz
+import pytest
+import pynapple as nap
+import numpy as np
+from PyQt6.QtWidgets import QApplication
+import sys
+
+
+@pytest.fixture(scope="module")  # or scope="session"
+def shared_test_files(tmp_path_factory):
+    """Create test files that persist across multiple tests."""
+    tmp_dir = tmp_path_factory.mktemp("data")
+
+    # Create your files
+    time = np.arange(10)
+    data = np.ones(10)
+    tsd = nap.Tsd(time, data)
+    tsd_frame = nap.TsdFrame(tsd.t, tsd.d[..., None])
+    tsd_tensor = nap.TsdTensor(tsd_frame.t, tsd_frame.d[..., None])
+    tsd.save(tmp_dir / "test_tsd.npz")
+    tsd_frame.save(tmp_dir / "test_tsd_frame.npz")
+    tsd_tensor.save(tmp_dir / "test_tsd_frame.npz")
+    expected_output = {
+        "Tsd": tsd,
+        "TsdFrame": tsd_frame,
+        "TsdTensor": tsd_tensor,
+    }
+    return tmp_dir, expected_output
+
+def test_load_files(shared_test_files):
+    path_dir, expected = shared_test_files
+    # Set up Qt application (ensure it's headless for testing)
+    if not QApplication.instance():
+        app = QApplication(sys.argv)
+        # Make headless for testing
+        app.setQuitOnLastWindowClosed(False)
+    else:
+        app = QApplication.instance()
+
+    main_window = viz.qt.mainwindow.MainWindow()
+    dock = viz.qt.mainwindow.MainDock({}, main_window)
+    main_window._load_multiple_files(path_dir.iterdir())
+    for var in dock.variables.values():
+        name = var.__class__.__name__
+        if name in ["Tsd", "TsdFrame", "TsdTensor"]:
+            np.testing.assert_array_equal(var.t, expected[name].t)
+            np.testing.assert_array_equal(var.d, expected[name].d)
+        elif name in ["NWBReference"]:
+            assert var.key == expected[name].key
+            assert var.nwb_file.path == expected[name].nwb_file.path
+
+
+
+

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -59,7 +59,7 @@ from pynaviz.qt.mainwindow import MainDock
 
 
 @pytest.fixture(scope='function')
-def main_window__dock(variables, qtbot):
+def main_window__dock(nap_var, qtbot):
     """
     Set up a MainWindow and a MainDock.
 
@@ -72,10 +72,10 @@ def main_window__dock(variables, qtbot):
     main_window = viz.qt.mainwindow.MainWindow()
     qtbot.addWidget(main_window)
 
-    dock = viz.qt.mainwindow.MainDock(variables, main_window)
+    dock = viz.qt.mainwindow.MainDock(nap_var, main_window)
     qtbot.addWidget(dock)
 
-    return main_window, dock, variables
+    return main_window, dock, nap_var
 
 
 def apply_action(
@@ -177,11 +177,13 @@ def apply_action(
 @pytest.mark.parametrize("apply_to", [("tsgroup",), ("tsdframe",), ("tsgroup", "tsdframe")])
 def test_save_load_layout_tsdframe(apply_to, main_window__dock, color_by_kwargs, group_by_kwargs, sort_by_kwargs,
                                    tmp_path, qtbot):
+
     main_window, dock, variables = main_window__dock
     # add widgets
     widget = None
+
     for varname in variables.keys():
-        dock_widget = dock.add_dock_widget(varname)
+        dock_widget = dock.add_dock_widget([varname])
         if varname in apply_to:
             widget = dock_widget.widget()
             apply_action(widget=widget, action_type="group_by" if group_by_kwargs is not None else None,
@@ -196,7 +198,7 @@ def test_save_load_layout_tsdframe(apply_to, main_window__dock, color_by_kwargs,
 
     layout_path = tmp_path / "layout.json"
     layout_dict_orig = dock._get_layout_dict()
-    dock.save_layout(layout_path)
+    dock._save_layout(layout_path)
 
     # load a main window with the same configs.
     main_window_new = viz.qt.mainwindow.MainWindow()
@@ -272,8 +274,9 @@ def test_save_load_layout_tsdframe_screenshots(apply_to, main_window__dock, colo
     main_window, dock, variables = main_window__dock
     # add widgets
     widget = None
+
     for varname in variables.keys():
-        dock_widget = dock.add_dock_widget(varname)
+        dock_widget = dock.add_dock_widget([varname])
         if varname in apply_to:
             widget = dock_widget.widget()
             apply_action(widget=widget, action_type="group_by" if group_by_kwargs is not None else None,
@@ -286,7 +289,8 @@ def test_save_load_layout_tsdframe_screenshots(apply_to, main_window__dock, colo
     assert widget is not None, "widget not created."
 
     layout_path = tmp_path / "layout.json"
-    dock.save_layout(layout_path)
+    dock._save_layout(layout_path)
+
 
     # Take screenshots
     orig_screenshots = {}


### PR DESCRIPTION
## File-Menu
- Add a file menu with open functionality. 
- - Switched from `QListWidget` to `QTreeWidget` for accommodating NWB files (which have a nested structure). 
- Create an NWBReference dataclass to store the referenc to the `pynapple.io.NWBFile` object and the variable key.
- store the full key path for each variable (as a dock property) to store it in the layout payload.
- store the set of open files as attribute of `MainWindow`.

## TODO

- Re-create all gifs in `docs/examples/`