### PR TITLE
fixed rendering

### DIFF
--- a/src/pynaviz/audiovideo/video_plot.py
+++ b/src/pynaviz/audiovideo/video_plot.py
@@ -347,7 +347,7 @@ class PlotVideo(PlotBaseVideoTensor):
 
         self.buffer_lock = threading.Lock()
         self._needs_redraw = threading.Event()
-        self.canvas.request_draw(self._render_loop)
+        self.canvas.request_draw(self.anmiate)
         self._last_jump_index = 0
 
     def _get_initial_texture_data(self):
@@ -465,7 +465,7 @@ class PlotVideo(PlotBaseVideoTensor):
         """Ensure all resources are closed when the object is destroyed."""
         self.close()
 
-    def _render_loop(self):
+    def anmiate(self):
         """
         Main render loop callback for pygfx.
 
@@ -500,4 +500,4 @@ class PlotVideo(PlotBaseVideoTensor):
             self.renderer.render(self.scene, self.camera)
             self._needs_redraw.clear()
 
-        self.canvas.request_draw(self._render_loop)
+        self.canvas.request_draw(self.anmiate)

--- a/src/pynaviz/qt/widget_menu.py
+++ b/src/pynaviz/qt/widget_menu.py
@@ -497,11 +497,7 @@ class MenuWidget(QWidget):
                     self.plot.scene.remove(self.plot.points[name].lines)
                 self.plot.scene.remove(self.plot.points[name].points)
                 del self.plot.points[name]
-            # if it is a PlotVideo object, use the async render loop
-            if hasattr(self.plot, "_render_loop"):
-                self.plot.canvas.request_draw(self.plot._render_loop)
-            # otherwise use hte standard plot.animate
-            else:
-                self.plot.canvas.request_draw(self.plot.animate)
+            self.plot.canvas.request_draw(self.plot.anmiate)
+
 
 


### PR DESCRIPTION
Bugfixed the remove overlay. The method was calling plot.animate, which is not the correct rendering function for PlotVideo. 
Currently, I kept original method name for the rendering function of PlotVideo ( `_rendering_loop`, which implements the async update), one question is the following, do we want to rename that as animate for consistency or do we want to keep it different to highlight the different rendering logic of this particular class?

I would probably prefer to call it `animate` to keep the classes consistent. 

> **Edit:** We ended up renaming the rendering callable to `animate` for consistency.