### PR TITLE
Dev

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+branch = True
+source = pynaviz
+
+[report]
+omit =
+    */site-packages/*
+    */shibokensupport/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pynaviz"
-version = "0.0.1"
+dynamic = ["version"]
 authors = [{name = "pynaviz authors"}]
 description = "Life made easier."
 readme = "README.md"
@@ -46,7 +46,7 @@ local_scheme = 'no-local-version'
 # Define optional dependencies for the project
 [project.optional-dependencies]
 qt = [
-    "pyqt6"
+    "pyside6"
 ]
 dev = [
     "pip-tools",                    # Dependency management
@@ -60,7 +60,7 @@ dev = [
     "isort",
     "click",
     "imageio",
-    "pyqt6",
+    "pyside6",
     "fsspec",                      # Download file from OSF for testing
     "aiohttp"
 ]
@@ -81,7 +81,7 @@ docs = [
     "myst-nb",
     "sphinx-autobuild",
     "sphinx-contributors",
-    "pyqt6",
+    "pyside6",
     "imageio"
     # "sphinx-excec-code"
 ]

--- a/src/pynaviz/__init__.py
+++ b/src/pynaviz/__init__.py
@@ -1,6 +1,12 @@
 from importlib.metadata import PackageNotFoundError as _PackageNotFoundError
 from importlib.metadata import version as _get_version
 
+try:
+    __version__ = _get_version("pynaviz")
+except _PackageNotFoundError:
+    # package is not installed
+    pass
+
 from .audiovideo import AudioHandler, PlotTsdTensor, PlotVideo, VideoHandler
 from .base_plot import (
     PlotIntervalSet,
@@ -22,35 +28,58 @@ __all__ = [
     "VideoHandler",
 ]
 
-try:
-    from .qt import (
-        IntervalSetWidget,
-        TsdFrameWidget,
-        TsdTensorWidget,
-        TsdWidget,
-        TsGroupWidget,
-        TsWidget,
-        VideoWidget,
-        scope,
-    )
+# ----------------------------------------------------------------------
+# Optional Qt imports
+# ----------------------------------------------------------------------
+def _load_qt():
+    """Lazy loader for the Qt widgets. Called only when the user needs Qt."""
+    try:
+        from .qt import (
+            IntervalSetWidget,
+            TsdFrameWidget,
+            TsdTensorWidget,
+            TsdWidget,
+            TsGroupWidget,
+            TsWidget,
+            VideoWidget,
+            scope,
+        )
+        return {
+            "IntervalSetWidget": IntervalSetWidget,
+            "TsdFrameWidget": TsdFrameWidget,
+            "TsdTensorWidget": TsdTensorWidget,
+            "TsdWidget": TsdWidget,
+            "TsGroupWidget": TsGroupWidget,
+            "TsWidget": TsWidget,
+            "VideoWidget": VideoWidget,
+            "scope": scope,
+        }
+    except ImportError as e:
+        raise ImportError(
+            "Qt support is not installed.\n"
+            "Install optional Qt dependencies with:\n\n"
+            "    pip install pynaviz[qt]\n"
+        ) from e
 
-    __all__ += [
-        "IntervalSetWidget",
-        "TsdFrameWidget",
-        "TsdTensorWidget",
-        "TsdWidget",
-        "TsGroupWidget",
-        "TsWidget",
-        "scope",
-        "VideoWidget"
-    ]
 
-except ImportError as e:
-    print(f"An error occurred when importing: {e}. Try installing with the [qt] extra. `pip install pynaviz[qt]`")
+# expose Qt attributes lazily
+def __getattr__(name):
+    qt_objects = _load_qt()
+    if name in qt_objects:
+        return qt_objects[name]
+    raise AttributeError(f"module 'pynaviz' has no attribute '{name}'")
 
 
-try:
-    __version__ = _get_version("pynaviz")
-except _PackageNotFoundError:
-    # package is not installed
-    pass
+# Add Qt names to __all__ for discoverability
+__all__ += [
+    "IntervalSetWidget",
+    "TsdFrameWidget",
+    "TsdTensorWidget",
+    "TsdWidget",
+    "TsGroupWidget",
+    "TsWidget",
+    "VideoWidget",
+    "scope",
+]
+
+

--- a/src/pynaviz/qt/drop_down_dict_builder.py
+++ b/src/pynaviz/qt/drop_down_dict_builder.py
@@ -2,8 +2,8 @@ import bisect
 from collections import OrderedDict
 
 import matplotlib.pyplot as plt
-from PyQt6.QtGui import QAction
-from PyQt6.QtWidgets import QComboBox, QWidget
+from PySide6.QtGui import QAction
+from PySide6.QtWidgets import QComboBox, QWidget
 
 from pynaviz.utils import GRADED_COLOR_LIST
 

--- a/src/pynaviz/qt/interval_sets_selection.py
+++ b/src/pynaviz/qt/interval_sets_selection.py
@@ -1,11 +1,11 @@
 
-from PyQt6.QtCore import (
+from PySide6.QtCore import (
     QAbstractTableModel,
     QModelIndex,
     Qt,
-    pyqtSignal,
+    Signal,
 )
-from PyQt6.QtWidgets import (
+from PySide6.QtWidgets import (
     QComboBox,
     QDialog,
     QDoubleSpinBox,
@@ -24,7 +24,7 @@ from pynaviz.utils import GRADED_COLOR_LIST
 class IntervalSetsModel(QAbstractTableModel):
     """A model to handle the dict of interval sets with checkboxes."""
 
-    checkStateChanged = pyqtSignal(str, str, float, bool)
+    checkStateChanged = Signal(str, str, float, bool)
 
     def __init__(self, interval_sets: dict):
         super().__init__()

--- a/src/pynaviz/qt/mainwindow.py
+++ b/src/pynaviz/qt/mainwindow.py
@@ -10,9 +10,9 @@ from datetime import datetime
 from typing import Any, Literal, Union
 
 import pynapple as nap
-from PyQt6.QtCore import QByteArray, QEvent, QPoint, QSize, Qt, QTimer
-from PyQt6.QtGui import QAction, QCursor, QFontMetrics, QIcon, QKeySequence, QPixmap, QShortcut
-from PyQt6.QtWidgets import (
+from PySide6.QtCore import QByteArray, QEvent, QPoint, QSize, Qt, QTimer
+from PySide6.QtGui import QAction, QCursor, QFontMetrics, QIcon, QKeySequence, QPixmap, QShortcut
+from PySide6.QtWidgets import (
     QApplication,
     QComboBox,
     QDockWidget,

--- a/src/pynaviz/qt/tsdframe_selection.py
+++ b/src/pynaviz/qt/tsdframe_selection.py
@@ -1,6 +1,6 @@
 
-from PyQt6.QtCore import QAbstractTableModel, QModelIndex, Qt, pyqtSignal
-from PyQt6.QtWidgets import (
+from PySide6.QtCore import QAbstractTableModel, QModelIndex, Qt, Signal
+from PySide6.QtWidgets import (
     QDialog,
     QDoubleSpinBox,
     QHBoxLayout,
@@ -52,7 +52,7 @@ class DoubleSpinDelegate(QStyledItemDelegate):
 class TsdFramesModel(QAbstractTableModel):
     """A model to handle the dict of tsdframes with checkboxes."""
 
-    checkStateChanged = pyqtSignal(str, str, float, float, bool)
+    checkStateChanged = Signal(str, str, float, float, bool)
 
     def __init__(self, tsdframes: dict):
         super().__init__()

--- a/src/pynaviz/qt/widget_list_selection.py
+++ b/src/pynaviz/qt/widget_list_selection.py
@@ -1,15 +1,15 @@
 from typing import Any
 
 import pynapple as nap
-from PyQt6.QtCore import (
+from PySide6.QtCore import (
     QAbstractListModel,
     QEvent,
     QItemSelectionModel,
     Qt,
     QTimer,
-    pyqtSignal,
+    Signal,
 )
-from PyQt6.QtWidgets import QDialog, QListView, QVBoxLayout, QWidget
+from PySide6.QtWidgets import QDialog, QListView, QVBoxLayout, QWidget
 
 
 class DynamicSelectionListView(QListView):
@@ -70,7 +70,7 @@ class DynamicSelectionListView(QListView):
 class ChannelListModel(QAbstractListModel):
     """A model to handle the list of channels with checkboxes."""
 
-    checkStateChanged = pyqtSignal(int)
+    checkStateChanged = Signal(int)
 
     def __init__(self, data: Any):
         super().__init__()
@@ -139,7 +139,7 @@ class ChannelListModel(QAbstractListModel):
 
 class ChannelList(QDialog):
 
-    checkStateChanged = pyqtSignal(int)
+    checkStateChanged = Signal(int)
 
     """
     A dialog listing selectable channels (e.g., for visibility toggling).
@@ -178,7 +178,7 @@ class ChannelList(QDialog):
 #
 #
 # class TsdFrameColumnListModel(QAbstractListModel):
-#     checkStateChanged = pyqtSignal(int)
+#     checkStateChanged = Signal(int)
 #
 #     def __init__(self, tsdframe):
 #         super().__init__()
@@ -234,7 +234,7 @@ class ChannelList(QDialog):
 # if __name__ == "__main__":
 #     import numpy as np
 #     import pynapple as nap
-#     from PyQt6.QtWidgets import QApplication, QListView
+#     from PySide6.QtWidgets import QApplication, QListView
 #
 #     my_tsdframe = nap.TsdFrame(
 #         t=np.arange(10),

--- a/src/pynaviz/qt/widget_menu.py
+++ b/src/pynaviz/qt/widget_menu.py
@@ -16,9 +16,9 @@ from typing import Any, Callable
 
 import numpy as np
 import pynapple as nap
-from PyQt6.QtCore import QPoint, QSize, Qt
-from PyQt6.QtGui import QAction
-from PyQt6.QtWidgets import (
+from PySide6.QtCore import QPoint, QSize, Qt
+from PySide6.QtGui import QAction
+from PySide6.QtWidgets import (
     QComboBox,
     QDialog,
     QDoubleSpinBox,

--- a/src/pynaviz/qt/widget_plot.py
+++ b/src/pynaviz/qt/widget_plot.py
@@ -8,9 +8,9 @@ from typing import Optional, Tuple
 
 import pynapple as nap
 from numpy._typing import NDArray
-from PyQt6.QtCore import QTimer
-from PyQt6.QtGui import QAction, QKeySequence
-from PyQt6.QtWidgets import QApplication, QVBoxLayout, QWidget
+from PySide6.QtCore import QTimer
+from PySide6.QtGui import QAction, QKeySequence
+from PySide6.QtWidgets import QApplication, QVBoxLayout, QWidget
 
 from .. import VideoHandler
 from ..audiovideo import PlotTsdTensor, PlotVideo

--- a/tests/_test_widget_menu.py
+++ b/tests/_test_widget_menu.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from unittest.mock import MagicMock
 
 import pytest
-from PyQt6.QtWidgets import QApplication, QComboBox, QDoubleSpinBox
+from PySide6.QtWidgets import QApplication, QComboBox, QDoubleSpinBox
 
 from pynaviz.qt.widget_list_selection import ChannelListModel
 from pynaviz.qt.widget_menu import ChannelList, DropdownDialog, MenuWidget, widget_factory

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ import sys
 from pathlib import Path
 
 import pytest
-from PyQt6.QtWidgets import QApplication
+from PySide6.QtWidgets import QApplication
 
 from pynaviz.cli import main
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,27 @@
+import sys
+
+import pytest
+
+import pynaviz
+
+
+# -----------------------------
+# Test 1: basic import works without Qt
+# -----------------------------
+def test_basic_import():
+    # Access non-Qt features
+    assert hasattr(pynaviz, "PlotTsd")
+    assert hasattr(pynaviz, "PlotVideo")
+
+# -----------------------------
+# Test 2: lazy Qt import raises ImportError if Qt is missing
+# -----------------------------
+def test_lazy_qt_import_raises(monkeypatch):
+    # simulate Qt not installed
+    # temporarily remove PySide6 if present
+    monkeypatch.setitem(sys.modules, "pynaviz.qt", None)
+
+    with pytest.raises(ImportError) as excinfo:
+        _ = pynaviz.TsdWidget  # triggers lazy import
+
+    assert "Qt support is not installed" in str(excinfo.value)

--- a/tests/test_interval_sets_selection.py
+++ b/tests/test_interval_sets_selection.py
@@ -6,8 +6,8 @@ from collections import OrderedDict
 
 import pynapple as nap
 import pytest
-from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QComboBox, QDoubleSpinBox, QPushButton
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QComboBox, QDoubleSpinBox, QPushButton
 
 from pynaviz.qt.interval_sets_selection import (
     ComboDelegate,
@@ -603,7 +603,7 @@ class TestSpinDelegate:
     @pytest.fixture
     def mock_parent(self, qtbot):
         """Create a mock parent widget."""
-        from PyQt6.QtWidgets import QWidget
+        from PySide6.QtWidgets import QWidget
         widget = QWidget()
         qtbot.addWidget(widget)
         return widget
@@ -785,7 +785,7 @@ class TestComboDelegate:
     @pytest.fixture
     def mock_parent(self, qtbot):
         """Create a mock parent widget."""
-        from PyQt6.QtWidgets import QWidget
+        from PySide6.QtWidgets import QWidget
         widget = QWidget()
         qtbot.addWidget(widget)
         return widget

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -2,7 +2,7 @@ from typing import Literal
 
 import numpy as np
 import pytest
-from PyQt6.QtWidgets import QDockWidget
+from PySide6.QtWidgets import QDockWidget
 
 import pynaviz as viz
 from pynaviz import (

--- a/tests/test_tsdframe_selection.py
+++ b/tests/test_tsdframe_selection.py
@@ -2,8 +2,8 @@ from collections import OrderedDict
 from unittest.mock import MagicMock
 
 import pytest
-from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QDoubleSpinBox, QPushButton
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QDoubleSpinBox, QPushButton
 
 from pynaviz.qt.tsdframe_selection import (
     GRADED_COLOR_LIST,
@@ -504,7 +504,7 @@ class TestDoubleSpinDelegate:
     @pytest.fixture
     def mock_parent(self, qtbot):
         """Create a mock parent widget."""
-        from PyQt6.QtWidgets import QWidget
+        from PySide6.QtWidgets import QWidget
         widget = QWidget()
         qtbot.addWidget(widget)
         return widget


### PR DESCRIPTION
This pull request migrates the codebase and tests from PyQt6 to PySide6 for Qt support, implements lazy loading for Qt widgets in `pynaviz`, and improves testability and error handling when Qt is not installed. The migration ensures consistent usage of PySide6 across all modules, simplifies optional dependency management, and provides a clearer error message for missing Qt support.

**Qt migration and dependency updates:**

* Replaced all `PyQt6` imports with `PySide6` in source files under `src/pynaviz/qt/` and in all relevant test files to standardize on PySide6 for Qt support. [[1]](diffhunk://#diff-60d47087d161e1e9efadcf5012096b1d5ff8908e7c7e6d6762a54a31db689c8dL5-R6) [[2]](diffhunk://#diff-9af366ff2fa0f4964c3e4269e542eecebbceb2aaecd5d95231b773ac35b6e086L2-R8) [[3]](diffhunk://#diff-9af366ff2fa0f4964c3e4269e542eecebbceb2aaecd5d95231b773ac35b6e086L27-R27) [[4]](diffhunk://#diff-add46207108b7bdfb55ac949247df9909366779be155c017ace015fb3d55bb6eL13-R15) [[5]](diffhunk://#diff-fc0ec18365862fb0b81013208aca57751080274e7231c179b5794676769ac4fdL2-R3) [[6]](diffhunk://#diff-fc0ec18365862fb0b81013208aca57751080274e7231c179b5794676769ac4fdL55-R55) [[7]](diffhunk://#diff-877fba3030c6f9c5047c61fa167d5348ccb71fd8f6f8c2dbc4e82b87a2562aedL4-R12) [[8]](diffhunk://#diff-877fba3030c6f9c5047c61fa167d5348ccb71fd8f6f8c2dbc4e82b87a2562aedL73-R73) [[9]](diffhunk://#diff-877fba3030c6f9c5047c61fa167d5348ccb71fd8f6f8c2dbc4e82b87a2562aedL142-R142) [[10]](diffhunk://#diff-877fba3030c6f9c5047c61fa167d5348ccb71fd8f6f8c2dbc4e82b87a2562aedL181-R181) [[11]](diffhunk://#diff-877fba3030c6f9c5047c61fa167d5348ccb71fd8f6f8c2dbc4e82b87a2562aedL237-R237) [[12]](diffhunk://#diff-93c8f59958f855e626078452c348b66f5649b1400f6529b67a2612a012ba0000L19-R21) [[13]](diffhunk://#diff-ed8358b115fb58a2b2636eb1f5a6ca0c3ecda1b57ddec56b486ca715fb7fa919L11-R13) [[14]](diffhunk://#diff-cf37abc2ccc9be972f678fc0b1263535ee363ed34f12c9ec8eab05bdc6d9a41dL6-R6) [[15]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eL5-R5) [[16]](diffhunk://#diff-74506b8753410e4eb4d76293ad2fe580dc9e5f8d7fc3bdb031034aef806b7f4aL9-R10) [[17]](diffhunk://#diff-74506b8753410e4eb4d76293ad2fe580dc9e5f8d7fc3bdb031034aef806b7f4aL606-R606) [[18]](diffhunk://#diff-74506b8753410e4eb4d76293ad2fe580dc9e5f8d7fc3bdb031034aef806b7f4aL788-R788) [[19]](diffhunk://#diff-3621ee7104e308f89f8e6357d230a88d4fa6883ef75bf5c17657c9275ce47148L5-R5) [[20]](diffhunk://#diff-fac738d760da7706f5bd34f2e121d31038d3491e3071f50f79e5bafffd44fa3eL5-R6) [[21]](diffhunk://#diff-fac738d760da7706f5bd34f2e121d31038d3491e3071f50f79e5bafffd44fa3eL507-R507)
* Updated optional dependencies in `pyproject.toml` to use `pyside6` instead of `pyqt6` for `qt`, `dev`, and `docs` extras. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L49-R49) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L63-R63) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L84-R84)

**Lazy Qt widget loading and error handling:**

* Refactored `src/pynaviz/__init__.py` to implement lazy loading for Qt widgets via a `_load_qt` function and `__getattr__`, raising a clear `ImportError` if Qt support is not installed and providing installation instructions. [[1]](diffhunk://#diff-b502f6b896fa9f46702df467f1eef599aa313bac8f3d34e9642828781651ae73R31-R35) [[2]](diffhunk://#diff-b502f6b896fa9f46702df467f1eef599aa313bac8f3d34e9642828781651ae73R47-L56)

**Testing improvements:**

* Added `tests/test_import.py` to verify that basic import works without Qt and that accessing Qt widgets raises an informative `ImportError` if Qt is missing.

**Coverage configuration:**

* Added a `.coveragerc` file to configure coverage reporting, including branch coverage and omitting site-packages and shibokensupport.

**Version handling:**

* Improved version detection in `src/pynaviz/__init__.py` to avoid errors if the package is not installed.