### PR TITLE
update pygfx pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 
 # Define dependencies for the project
 dependencies = [    
-    "pygfx>=0.14.0",
+    "pygfx==0.15.3",
     "pynapple>=0.9.0",
     "glfw",
     "matplotlib",


### PR DESCRIPTION
updates the pygfx pin to account for recent changes in wgpu and rendercanvas, has no effect for users but CI fails with without bounds on rendercanvas

see: https://github.com/pygfx/pygfx/releases/tag/v0.15.2 and https://github.com/pygfx/pygfx/releases/tag/v0.15.3