### PR TITLE
Fix TypeError in PlotVideo on Windows devices

### DIFF
--- a/src/pynaviz/audiovideo/video_plot.py
+++ b/src/pynaviz/audiovideo/video_plot.py
@@ -325,7 +325,7 @@ class PlotVideo(PlotBaseVideoTensor):
             # Queues and events for IPC
             self._buffer_thread = threading.Thread(target=self._update_buffer_thread, daemon=True)
             self.shm_frame = shared_memory.SharedMemory(
-                create=True, size=np.prod(self.shape) * np.float32().nbytes
+                create=True, size=int(np.prod(self.shape)) * np.float32().nbytes
             )
             self.shm_index = shared_memory.SharedMemory(create=True, size=np.float32().nbytes)
             self.shared_frame = np.ndarray(self.shape, dtype=np.float32, buffer=self.shm_frame.buf)


### PR DESCRIPTION
### Problem
On Windows 11, `PlotVideo` raises the following error when opening a video:
`TypeError: CreateFileMapping() argument 4 must be int, not numpy.int64`
<details>
<summary>Full traceback</summary>

```python-traceback
PS C:\Users\user\pynaviz> & C:/Users/user/pynaviz/.venv/Scripts/python.exe c:/Users/user/pynaviz/main.py
Traceback (most recent call last):
  File "C:\Users\user\pynaviz\src\pynaviz\qt\mainwindow.py", line 304, in on_item_double_clicked
    self.add_dock_widget(item)
  File "C:\Users\user\pynaviz\src\pynaviz\qt\mainwindow.py", line 334, in add_dock_widget
    self.gui.add_dock_widget(variable, key_path)
  File "C:\Users\user\pynaviz\src\pynaviz\qt\mainwindow.py", line 855, in add_dock_widget
    widget = self._create_widget_for_variable(variable)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\user\pynaviz\src\pynaviz\qt\mainwindow.py", line 811, in _create_widget_for_variable
    return VideoWidget(var, index=index, set_parent=True, tsdframes=tsdframes)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\user\pynaviz\src\pynaviz\qt\widget_plot.py", line 263, in __init__
    self.plot = PlotVideo(video=video, t=t, stream_index=stream_index, index=index, parent=parent)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\user\pynaviz\src\pynaviz\audiovideo\video_plot.py", line 327, in __init__
    self.shm_frame = shared_memory.SharedMemory(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\user\AppData\Roaming\uv\python\cpython-3.12.12-windows-x86_64-none\Lib\multiprocessing\shared_memory.py", line 131, in __init__
    h_map = _winapi.CreateFileMapping(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: CreateFileMapping() argument 4 must be int, not numpy.int64
```

</details>

### Fix
The issue seems to be in `audiovideo/video_plot.py` line 328, when creating `SharedMemory` the `size` parameter is passed as `numpy.int64`. After explicitly casting the parameter passed as `int`, videos open normally on Windows for me.
`size=int(np.prod(self.shape)) * np.float32().nbytes`
