### PR TITLE
Dev

### DIFF
--- a/src/pynaviz/audiovideo/video_plot.py
+++ b/src/pynaviz/audiovideo/video_plot.py
@@ -325,7 +325,7 @@ class PlotVideo(PlotBaseVideoTensor):
             # Queues and events for IPC
             self._buffer_thread = threading.Thread(target=self._update_buffer_thread, daemon=True)
             self.shm_frame = shared_memory.SharedMemory(
-                create=True, size=np.prod(self.shape) * np.float32().nbytes
+                create=True, size=int(np.prod(self.shape)) * np.float32().nbytes
             )
             self.shm_index = shared_memory.SharedMemory(create=True, size=np.float32().nbytes)
             self.shared_frame = np.ndarray(self.shape, dtype=np.float32, buffer=self.shm_frame.buf)


### PR DESCRIPTION
This pull request makes a minor fix to the initialization of shared memory in the `video_plot.py` module. The change ensures that the size parameter passed to `SharedMemory` is always an integer, which improves compatibility and prevents potential errors.

* Initialization fix:
  * In the `__init__` method of `src/pynaviz/audiovideo/video_plot.py`, the calculation for the shared memory size now explicitly casts the result of `np.prod(self.shape)` to an integer before multiplying by the number of bytes, ensuring correct type handling.