### PR TITLE
TsdFrame image

### DIFF
--- a/src/pynaviz/audiovideo/video_plot.py
+++ b/src/pynaviz/audiovideo/video_plot.py
@@ -125,7 +125,7 @@ class PlotBaseVideoTensor(_BasePlot, ABC):
             controller_id=index,
             data=self._data,
             buffer=self.texture,
-            callback=self._update_buffer,
+            plot_callbacks=[self._update_buffer],
         )
 
         # List to hold time series points that can be superposed

--- a/src/pynaviz/base_plot.py
+++ b/src/pynaviz/base_plot.py
@@ -116,7 +116,7 @@ class _BasePlot(IntervalSetInterface):
         Default colormap name used for visual mapping (e.g., "viridis").
     """
 
-    def __init__(self, data, parent=None, maintain_aspect=False):
+    def __init__(self, data, parent=None, maintain_aspect=False, background="black"):
         super().__init__()
 
         # Store the input data for later use
@@ -140,6 +140,10 @@ class _BasePlot(IntervalSetInterface):
 
         # Create a new scene to hold and manage objects
         self.scene = gfx.Scene()
+
+        # Store and optionally render the background color
+        self._background = background
+        self.scene.add(gfx.Background.from_color(background))
 
         # Add a horizontal ruler (x-axis) with ticks above
         self.ruler_x = gfx.Ruler(
@@ -212,6 +216,17 @@ class _BasePlot(IntervalSetInterface):
             )
             return
         self._cmap = value
+
+    def _default_line_color(self):
+        """Return a line color that contrasts with the background.
+
+        Returns "black" for light backgrounds and "white" for dark or unset backgrounds.
+        """
+        if self._background == "black":
+            return "white"
+        c = gfx.Color(self._background)
+        luminance = 0.299 * c.r + 0.587 * c.g + 0.114 * c.b
+        return "black" if luminance > 0.5 else "white"
 
     def animate(self):
         """
@@ -391,9 +406,10 @@ class PlotTsd(_BasePlot):
     """
 
     def __init__(
-        self, data: nap.Tsd, index: Optional[int] = None, parent: Optional[Any] = None
+        self, data: nap.Tsd, index: Optional[int] = None, parent: Optional[Any] = None,
+        background: Optional[str] = "black",
     ) -> None:
-        super().__init__(data=data, parent=parent)
+        super().__init__(data=data, parent=parent, background=background)
 
         # Create a controller for span-based interaction, syncing, and user inputs
         self.controller = SpanController(
@@ -452,6 +468,8 @@ class PlotTsdFrame(_BasePlot):
         up to 256 MB of memory.
     display_mode : str, default "lines"
         Initial display mode ("lines" or "image"). Toggle with the "m" key.
+    background : str or tuple, optional
+        Background color (e.g. ``"white"``, ``"black"``, ``"#272822"``).
     """
 
     def __init__(
@@ -461,18 +479,20 @@ class PlotTsdFrame(_BasePlot):
         parent: Optional[Any] = None,
         window_size: Optional[float] = None,
         display_mode: str = "lines",
+        background: Optional[str] = "black",
     ):
-        super().__init__(data=data, parent=parent)
+        super().__init__(data=data, parent=parent, background=background)
         self._data = data
 
         if display_mode not in ("lines", "image"):
             raise ValueError(f"display_mode must be 'lines' or 'image', got '{display_mode}'")
         self._display_mode = display_mode
 
+        default_color = self._default_line_color()
         self._modes = {
-            "lines": LinesMode(data, self._manager, window_size),
+            "lines": LinesMode(data, self._manager, window_size, default_color=default_color),
             "image": ImageMode(data, self._manager),
-            "x_vs_y": XvsYMode(data, self._manager),
+            "x_vs_y": XvsYMode(data, self._manager, default_color=default_color),
         }
         self._mode = self._modes[display_mode]
         self._mode.initialize_graphic()
@@ -503,7 +523,7 @@ class PlotTsdFrame(_BasePlot):
                 renderer=self.renderer,
                 data=None,
                 buffer=None,
-                callback=self._modes["x_vs_y"]._update_buffer,
+                plot_callbacks=self._modes["x_vs_y"].get_callbacks(),
                 enabled=False,
             ),
         }
@@ -626,7 +646,10 @@ class PlotTsdFrame(_BasePlot):
                 )
                 self.controller.set_ylim(0, self.data.shape[1])
             else:
-                self.controller.set_ylim(float(np.nanmin(minmax[:, 0])), float(np.nanmax(minmax[:, 1])))
+                if self._manager.is_sorted or self._manager.is_grouped:
+                    self.controller.set_ylim(0, float(np.max(self._manager.offset) + 1))
+                else:
+                    self.controller.set_ylim(float(np.nanmin(minmax[:, 0])), float(np.nanmax(minmax[:, 1])))
             self.canvas.request_draw(self.animate)
 
     def _update(self, action_name):
@@ -729,7 +752,7 @@ class PlotTsdFrame(_BasePlot):
         self,
         x_col: Union[str, int, float],
         y_col: Union[str, int, float],
-        color: Union[str, tuple] = "white",
+        color: Union[str, tuple] = None,
         thickness: float = 1.0,
         markersize: float = 10.0,
     ) -> None:
@@ -741,8 +764,8 @@ class PlotTsdFrame(_BasePlot):
             Column name for the x-axis.
         y_col : str or int or float
             Column name for the y-axis.
-        color : str or tuple, default "white"
-            Line color.
+        color : str or tuple, optional
+            Line color. Defaults to a color that contrasts with the background.
         thickness : float, default 1.0
             Line thickness.
         markersize : float, default 10.0
@@ -757,6 +780,8 @@ class PlotTsdFrame(_BasePlot):
         self._display_mode = "x_vs_y"
         self._mode = self._modes["x_vs_y"]
         self._mode._request_draw = lambda: self.canvas.request_draw(self.animate)
+        if color is None:
+            color = self._default_line_color()
         self._mode.update_parameters(x_col, y_col, color, thickness, markersize)
         self._mode.initialize_graphic()
         self.scene.add(self._mode.graphic)
@@ -794,9 +819,9 @@ class PlotTsGroup(_BasePlot):
         Parent widget in a Qt application, if applicable.
     """
 
-    def __init__(self, data: nap.TsGroup, index=None, parent=None):
+    def __init__(self, data: nap.TsGroup, index=None, parent=None, background: Optional[str] = "black"):
         # Initialize the base plot with provided data
-        super().__init__(data=data, parent=parent)
+        super().__init__(data=data, parent=parent, background=background)
 
         # Pynaviz-specific controller that handles pan/zoom and synchronization
         self.controller = SpanController(
@@ -977,9 +1002,9 @@ class PlotTs(_BasePlot):
 
     """
 
-    def __init__(self, data: nap.Ts, index=None, parent=None):
+    def __init__(self, data: nap.Ts, index=None, parent=None, background: Optional[str] = "black"):
         # Initialize the base plot with provided data
-        super().__init__(data=data, parent=parent)
+        super().__init__(data=data, parent=parent, background=background)
 
         # Disable aspect ratio lock (x and y can scale independently)
         self.camera.maintain_aspect = False
@@ -1090,8 +1115,8 @@ class PlotIntervalSet(_BasePlot):
         Dictionary of rectangle meshes for each interval.
     """
 
-    def __init__(self, data: nap.IntervalSet, index=None, parent=None):
-        super().__init__(data=data, parent=parent)
+    def __init__(self, data: nap.IntervalSet, index=None, parent=None, background: Optional[str] = "black"):
+        super().__init__(data=data, parent=parent, background=background)
         self.camera.maintain_aspect = False
 
         # Pynaviz specific controller

--- a/src/pynaviz/base_plot.py
+++ b/src/pynaviz/base_plot.py
@@ -29,7 +29,6 @@ from .synchronization_rules import (
 from .threads.metadata_to_color_maps import MetadataMappingThread
 from .utils import (
     GRADED_COLOR_LIST,
-    RenderTriggerSource,
     get_plot_attribute,
     get_plot_min_max,
     trim_kwargs,

--- a/src/pynaviz/controller.py
+++ b/src/pynaviz/controller.py
@@ -278,6 +278,7 @@ class SpanController(CustomController):
         # To make sure all controller stays in sync
         self._send_sync_event(update_type="pan", current_time=target_time)
 
+
 class SpanYLockController(SpanController):
     """
     Horizontal time-panning with y-axis locked

--- a/src/pynaviz/controller.py
+++ b/src/pynaviz/controller.py
@@ -333,7 +333,7 @@ class GetController(CustomController):
         controller_id: Optional[int] = None,
         data: Optional[Any] = None,
         buffer: pygfx.Buffer = None,
-        callback: Optional[Callable] = None,
+        plot_callbacks: Optional[list[Callable]] = None,
     ):
         super().__init__(
             camera=camera,
@@ -350,7 +350,7 @@ class GetController(CustomController):
             self._current_time = None
 
         self.buffer = buffer
-        self._plot_callbacks = [callback] if callback is not None else []
+        self._plot_callbacks = list(plot_callbacks) if plot_callbacks is not None else []
 
     def set_view(self, xmin: float, xmax: float, ymin: float, ymax: float):
         """Set the visible X and Y ranges for an OrthographicCamera."""

--- a/src/pynaviz/display_modes.py
+++ b/src/pynaviz/display_modes.py
@@ -1,0 +1,421 @@
+"""
+Display mode strategies for PlotTsdFrame.
+
+Each mode encapsulates how GPU buffers are populated, how rescaling works,
+how coloring is applied, and how the mode activates/deactivates in the scene.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pygfx as gfx
+from matplotlib.pyplot import colormaps
+
+from .threads.data_streaming import TsdFrameStreaming
+from .utils import trim_kwargs
+
+
+class LinesMode:
+    """Standard line-plot display mode with vertex colors.
+
+    Each channel is stored as a contiguous segment in a shared positions buffer,
+    separated by NaN gaps. Colors are per-vertex (RGBA).
+
+    Parameters
+    ----------
+    data : nap.TsdFrame
+        The time series data to display.
+    manager : PlotTsdFrameManager
+        Manages per-channel metadata (offset, scale, visibility, etc.).
+    window_size : float, optional
+        Streaming window duration in seconds. If None, computed to fit
+        up to 256 MB of memory.
+    """
+
+    controller_key = "span"
+
+    def __init__(self, data, manager, window_size=None):
+        self.data = data
+        self.window_size = window_size
+        self.manager = manager
+        if window_size is None:
+            size = (256 * 1024**2) // (data.shape[1] * 60)
+            window_size = np.floor(size / data.rate)
+            if window_size < 1:
+                window_size = 1.0
+
+        self.stream = TsdFrameStreaming(
+            data, callback=self.flush, window_size=window_size
+        )
+
+        # Shared positions buffer: (max_n+1)*n_channels rows, NaN-separated per channel
+        self.buffer = np.full(
+            ((self.stream._max_n + 1) * self.data.shape[1], 3), np.nan, dtype="float32"
+        )
+        self._buffer_slices = {}
+        for c, s in zip(
+            self.data.columns,
+            range(
+                0,
+                len(self.buffer) - self.stream._max_n + 1,
+                self.stream._max_n + 1,
+            ),
+        ):
+            self._buffer_slices[c] = slice(s, s + self.stream._max_n)
+
+        self.buffer[:, 2] = 0.0
+
+    def initialize_graphic(self):
+        """Create the gfx.Line graphic (no-op if already created)."""
+        if hasattr(self, "graphic"):
+            return
+        colors = np.ones((self.buffer.shape[0], 4), dtype=np.float32)
+        self.graphic = gfx.Line(
+            gfx.Geometry(positions=self.buffer, colors=colors),
+            gfx.LineMaterial(thickness=1.0, color_mode="vertex"),
+        )
+
+    def get_callbacks(self):
+        """Return streaming callbacks for the controller, if needed."""
+        if self.stream._max_n < self.data.shape[0]:
+            return [self.stream.stream]
+        return []
+
+    def flush(self, slice_=None):
+        """Populate the positions buffer from data and push to the GPU.
+
+        Parameters
+        ----------
+        slice_ : slice, optional
+            Data slice for streaming mode. Ignored when all data fits in memory.
+        """
+        if self.stream._max_n == self.data.shape[0]:
+            for i, c in enumerate(self.data.columns):
+                sl = self._buffer_slices[c]
+                self.buffer[sl, 0] = self.data.t.astype("float32")
+                self.buffer[sl, 1] = self.data.d[:, i].astype("float32")
+                self.buffer[sl, 1] *= self.manager.data.loc[c]["scale"]
+                self.buffer[sl, 1] += self.manager.data.loc[c]["offset"]
+        else:
+            time = self.data.t[slice_].astype("float32")
+
+            left_offset = 0
+            right_offset = 0
+            if time.shape[0] < self.stream._max_n:
+                if slice_.start == 0:
+                    left_offset = self.stream._max_n - time.shape[0]
+                else:
+                    right_offset = time.shape[0] - self.stream._max_n
+
+            data = np.array(self.data.values[slice_, :])
+
+            for i, c in enumerate(self.data.columns):
+                sl = self._buffer_slices[c]
+                sl = slice(sl.start + left_offset, sl.stop + right_offset)
+                self.buffer[sl, 0] = time
+                self.buffer[sl, 1] = data[:, i]
+                self.buffer[sl, 1] *= self.manager.data.loc[c]["scale"]
+                self.buffer[sl, 1] += self.manager.data.loc[c]["offset"]
+
+            if left_offset:
+                for sl in self._buffer_slices.values():
+                    self.buffer[sl.start : sl.start + left_offset, 0:2] = np.nan
+            if right_offset:
+                for sl in self._buffer_slices.values():
+                    self.buffer[sl.stop + right_offset : sl.stop, 0:2] = np.nan
+
+        self.graphic.geometry.positions.set_data(self.buffer)
+
+    def get_buffer_min_max(self):
+        """Return per-channel [min, max] from the current buffer.
+
+        Returns
+        -------
+        np.ndarray
+            Shape (n_channels, 2).
+        """
+        return np.array(
+            [
+                [np.nanmin(self.buffer[sl, 1]), np.nanmax(self.buffer[sl, 1])]
+                for sl in self._buffer_slices.values()
+            ]
+        )
+
+    def rescale(self, key):
+        """Scale channel amplitudes with 'i' (increase) or 'd' (decrease).
+
+        Returns False if channels are not sorted/grouped.
+        """
+        if not (self.manager.is_sorted or self.manager.is_grouped):
+            return False
+        factor = {"i": 0.5, "d": -0.5}[key]
+        self.manager.rescale(factor=factor)
+        for c, sl in self._buffer_slices.items():
+            self.buffer[sl, 1] += factor * (
+                self.buffer[sl, 1] - self.manager.data.loc[c]["offset"]
+            )
+        self.graphic.geometry.positions.set_data(self.buffer)
+        return True
+
+    def color_by(self, cmap_name, metadata_name, vmin, vmax, map_to_colors, values):
+        """Apply per-channel vertex colors from a metadata field."""
+        map_kwargs = trim_kwargs(
+            map_to_colors, dict(cmap=colormaps[cmap_name], vmin=vmin, vmax=vmax)
+        )
+        if len(values):
+            map_color = map_to_colors(values, **map_kwargs)
+            if map_color:
+                for c, sl in self._buffer_slices.items():
+                    self.graphic.geometry.colors.data[sl, :] = map_color[values[c]]
+                self.graphic.geometry.colors.update_full()
+
+        self.manager.color_by(values, metadata_name, cmap_name=cmap_name, vmin=vmin, vmax=vmax)
+
+    def update_visibility(self):
+        """Toggle channel visibility via the alpha channel of vertex colors."""
+        new_colors = self.graphic.geometry.colors.data.copy()
+        for c, sl in self._buffer_slices.items():
+            if not self.manager.data.loc[c]["visible"]:
+                new_colors[sl, -1] = 0.0
+            else:
+                new_colors[sl, -1] = 1.0
+        self.graphic.geometry.colors.set_data(new_colors)
+
+
+class ImageMode:
+    """Heatmap display mode with a 2D texture and locked y-axis.
+
+    The image buffer has shape (n_channels, max_n). When some channels are
+    hidden, the texture is recreated with only the visible rows so the image
+    shrinks vertically.
+
+    Parameters
+    ----------
+    data : nap.TsdFrame
+        The time series data to display.
+    manager : PlotTsdFrameManager
+        Manages per-channel metadata (offset, scale, visibility, etc.).
+    max_n : int, default 16384
+        Maximum number of time points in the image buffer (GPU texture width).
+    """
+
+    controller_key = "span_ylock"
+
+    def __init__(self, data, manager, max_n=16384):
+        self.data = data
+        self.manager = manager
+        self.window_size = np.maximum(max_n / data.rate, 1.0)
+
+        self.stream = TsdFrameStreaming(
+            data, callback=self.flush, window_size=self.window_size
+        )
+
+        self.buffer = np.zeros((data.shape[1], self.stream._max_n), dtype="float32")
+        self._n_visible = data.shape[1]
+
+    def initialize_graphic(self):
+        """Create the gfx.Image graphic and texture (no-op if already created)."""
+        if all(hasattr(self, attr) for attr in ["graphic", "texture"]):
+            return
+        self.texture = gfx.Texture(self.buffer, dim=2)
+        self.graphic = gfx.Image(
+            gfx.Geometry(grid=self.texture),
+            gfx.ImageBasicMaterial(clim=(0, 1), map=gfx.cm.viridis),
+        )
+        self.graphic.local.z = -10.0
+
+    def get_callbacks(self):
+        """Return streaming callbacks for the controller, if needed."""
+        if self.stream._max_n < self.data.shape[0]:
+            return [self.stream.stream]
+        return []
+
+    def flush(self, slice_=None):
+        """Fill the image buffer from data and update the texture.
+
+        Parameters
+        ----------
+        slice_ : slice, optional
+            Data slice for streaming mode. Ignored when all data fits in memory.
+        """
+        if self.stream._max_n == self.data.shape[0]:
+            raw = self.data.d[:, :].astype("float32").T
+            raw = self._reorder_image_rows(raw)
+            self.buffer[:, :] = 0.0
+            if raw.shape[1] > self.stream._max_n:
+                idx = np.linspace(0, raw.shape[1] - 1, self.stream._max_n, dtype=int)
+                self.buffer[:, :] = raw[:, idx]
+                n_filled = self.stream._max_n
+            else:
+                self.buffer[:, :raw.shape[1]] = raw
+                n_filled = raw.shape[1]
+            t_start = float(self.data.t[0])
+            t_end = float(self.data.t[-1])
+        else:
+            data = np.array(self.data.values[slice_, :])
+            raw_img = data.T.astype("float32")
+            raw_img = self._reorder_image_rows(raw_img)
+            self.buffer[:, :] = 0.0
+            if raw_img.shape[1] > self.stream._max_n:
+                idx = np.linspace(0, raw_img.shape[1] - 1, self.stream._max_n, dtype=int)
+                self.buffer[:, :] = raw_img[:, idx]
+                n_filled = self.stream._max_n
+            else:
+                self.buffer[:, :raw_img.shape[1]] = raw_img
+                n_filled = raw_img.shape[1]
+            t_start = float(self.data.t[slice_.start])
+            t_end = float(self.data.t[min(slice_.stop, self.data.shape[0]) - 1])
+
+        # Extract only visible rows for the texture
+        visible_buf = self._get_visible_buffer()
+        n_visible = visible_buf.shape[0]
+
+        if n_visible != self._n_visible:
+            self._n_visible = n_visible
+            self.texture = gfx.Texture(visible_buf.copy(), dim=2)
+            self.graphic.geometry.grid = self.texture
+        else:
+            self.texture.data[:] = visible_buf
+            self.texture.update_full()
+
+        # Align image pixels to actual time positions on the x-axis.
+        # Uses n_filled (actual data pixels) not buffer width, otherwise the
+        # image is compressed when data doesn't fill the entire buffer.
+        self.graphic.local.x = t_start
+        self.graphic.local.scale_x = (t_end - t_start) / n_filled
+
+    def rescale(self, key):
+        """Adjust color limits with 'i' (narrow) or 'd' (widen)."""
+        factor = {"i": 0.8, "d": 1.25}[key]
+        lo, hi = self.graphic.material.clim
+        center = (lo + hi) / 2
+        half = (hi - lo) / 2
+        new_half = half * factor
+        self.graphic.material.clim = (center - new_half, center + new_half)
+
+    def color_by(self, cmap_name, metadata_name, vmin, vmax, map_to_colors, values):
+        """Change the image colormap and color limits."""
+        cmap_map = getattr(gfx.cm, cmap_name, None)
+        if cmap_map is not None:
+            self.graphic.material.map = cmap_map
+        self.graphic.material.clim = (vmin, vmax)
+
+    def update_visibility(self):
+        """Re-flush to shrink/grow the image based on visible channels."""
+        self.flush(self.stream._slice_)
+
+    def _get_visible_buffer(self):
+        """Extract only visible channel rows from the buffer in display order.
+
+        Returns the full buffer when all channels are visible, or a new array
+        with only the visible rows otherwise.
+        """
+        if self.manager.is_sorted or self.manager.is_grouped:
+            offsets = np.array([
+                self.manager.data.loc[c]["offset"] for c in self.data.columns
+            ])
+            order = np.argsort(offsets)
+        else:
+            order = np.arange(len(self.data.columns))
+
+        visible_mask = np.array([
+            self.manager.data.loc[self.data.columns[idx]]["visible"]
+            for idx in order
+        ])
+
+        if visible_mask.all():
+            return self.buffer
+        return self.buffer[visible_mask, :]
+
+    def _reorder_image_rows(self, raw):
+        """Reorder image rows according to manager offsets (sort/group order).
+
+        Parameters
+        ----------
+        raw : np.ndarray
+            Image data of shape (n_channels, n_timepoints) in original column order.
+
+        Returns
+        -------
+        np.ndarray
+            Reordered array with rows placed according to manager offsets.
+        """
+        if not (self.manager.is_sorted or self.manager.is_grouped):
+            return raw
+
+        offsets = np.array([
+            self.manager.data.loc[c]["offset"]
+            for c in self.data.columns
+        ])
+        order = np.argsort(offsets)
+        return raw[order]
+
+    def get_buffer_min_max(self):
+        """Return per-time-point [min, max] from the current buffer.
+
+        Returns
+        -------
+        np.ndarray
+            Shape (max_n, 2).
+        """
+        return np.stack([np.nanmin(self.buffer, 0), np.nanmax(self.buffer, 0)]).T
+
+
+class XvsYMode:
+    """Scatter/line x-vs-y display mode using a GetController.
+
+    Plots one TsdFrame column against another. A red marker tracks the
+    current time point.
+
+    Parameters
+    ----------
+    data : nap.TsdFrame
+        The time series data.
+    manager : PlotTsdFrameManager
+        Manages per-channel metadata.
+    window_size : float, optional
+        Unused (kept for interface consistency).
+    """
+
+    controller_key = "get"
+
+    def __init__(self, data, manager, window_size=None):
+        self.data = data
+        self.manager = manager
+        self.window_size = window_size
+        self.x_col = None
+        self.y_col = None
+        self.color = "white"
+        self.thickness = 1.0
+        self.markersize = 10.0
+        self._request_draw = None
+
+    def initialize_graphic(self):
+        """Create the line graphic and time-point marker."""
+        xy_values = self.data.loc[[self.x_col, self.y_col]].values.astype("float32")
+        self.buffer = np.zeros((len(self.data), 3), dtype="float32")
+        self.buffer[:, 0:2] = xy_values
+        self.graphic = gfx.Line(
+            gfx.Geometry(positions=self.buffer),
+            gfx.LineMaterial(thickness=self.thickness, color=self.color),
+        )
+        xy = np.array([[0.0, 0.0, 1.0]], dtype="float32")
+        self.time_point = gfx.Points(
+            gfx.Geometry(positions=xy),
+            gfx.PointsMaterial(size=self.markersize, color="red", opacity=1),
+        )
+
+    def update_parameters(self, x_col, y_col, color="white", thickness=1.0, markersize=10.0):
+        """Set plotting parameters before calling initialize_graphic."""
+        self.x_col = x_col
+        self.y_col = y_col
+        self.color = color
+        self.thickness = thickness
+        self.markersize = markersize
+
+    def _update_buffer(self, frame_index, event_type=None):
+        """Move the time-point marker to the given frame index."""
+        self.time_point.geometry.positions.data[0, 0:2] = self.graphic.geometry.positions.data[frame_index, 0:2]
+        self.time_point.geometry.positions.update_full()
+        if self._request_draw is not None:
+            self._request_draw()

--- a/src/pynaviz/display_modes.py
+++ b/src/pynaviz/display_modes.py
@@ -34,10 +34,11 @@ class LinesMode:
 
     controller_key = "span"
 
-    def __init__(self, data, manager, window_size=None):
+    def __init__(self, data, manager, window_size=None, default_color="white"):
         self.data = data
         self.window_size = window_size
         self.manager = manager
+        self._default_color = default_color
         if window_size is None:
             size = (256 * 1024**2) // (data.shape[1] * 60)
             window_size = np.floor(size / data.rate)
@@ -69,7 +70,11 @@ class LinesMode:
         """Create the gfx.Line graphic (no-op if already created)."""
         if hasattr(self, "graphic"):
             return
-        colors = np.ones((self.buffer.shape[0], 4), dtype=np.float32)
+        c = gfx.Color(self._default_color)
+        colors = np.tile(
+            np.array([c.r, c.g, c.b, c.a], dtype=np.float32),
+            (self.buffer.shape[0], 1),
+        )
         self.graphic = gfx.Line(
             gfx.Geometry(positions=self.buffer, colors=colors),
             gfx.LineMaterial(thickness=1.0, color_mode="vertex"),
@@ -379,13 +384,13 @@ class XvsYMode:
 
     controller_key = "get"
 
-    def __init__(self, data, manager, window_size=None):
+    def __init__(self, data, manager, window_size=None, default_color="white"):
         self.data = data
         self.manager = manager
         self.window_size = window_size
         self.x_col = None
         self.y_col = None
-        self.color = "white"
+        self.color = default_color
         self.thickness = 1.0
         self.markersize = 10.0
         self._request_draw = None
@@ -405,13 +410,18 @@ class XvsYMode:
             gfx.PointsMaterial(size=self.markersize, color="red", opacity=1),
         )
 
-    def update_parameters(self, x_col, y_col, color="white", thickness=1.0, markersize=10.0):
+    def update_parameters(self, x_col, y_col, color=None, thickness=1.0, markersize=10.0):
         """Set plotting parameters before calling initialize_graphic."""
         self.x_col = x_col
         self.y_col = y_col
-        self.color = color
+        if color is not None:
+            self.color = color
         self.thickness = thickness
         self.markersize = markersize
+
+    def get_callbacks(self):
+        """Return the frame-update callback for the GetController."""
+        return [self._update_buffer]
 
     def _update_buffer(self, frame_index, event_type=None):
         """Move the time-point marker to the given frame index."""

--- a/src/pynaviz/display_modes.py
+++ b/src/pynaviz/display_modes.py
@@ -112,6 +112,7 @@ class LinesMode:
                 else:
                     right_offset = time.shape[0] - self.stream._max_n
 
+            # Load the current slice of data into the buffer, applying scale and offset.
             data = np.array(self.data.values[slice_, :])
 
             for i, c in enumerate(self.data.columns):

--- a/src/pynaviz/qt/widget_menu.py
+++ b/src/pynaviz/qt/widget_menu.py
@@ -12,6 +12,7 @@ Main Classes:
 """
 
 from collections import OrderedDict
+from types import SimpleNamespace
 from typing import Any, Callable
 
 import numpy as np
@@ -443,6 +444,9 @@ class MenuWidget(QWidget):
             return
         if popup_name in ["overlay_time_series", "overlay_skeleton"]:
             self.show_overlay_menu(popup_name)
+            return
+        if popup_name == "heatmap":
+            self.plot._toggle_display_mode(SimpleNamespace(type="key_down", key="m"))
             return
 
         kwargs = get_popup_kwargs(popup_name, self, action)

--- a/src/pynaviz/qt/widget_plot.py
+++ b/src/pynaviz/qt/widget_plot.py
@@ -133,12 +133,12 @@ class TsdWidget(BaseWidget):
 
 class TsdFrameWidget(BaseWidget):
 
-    def __init__(self, data, index=None, size=(640, 480), set_parent=True, interval_sets=None):
+    def __init__(self, data, index=None, size=(640, 480), set_parent=True, interval_sets=None, display_mode="lines"):
         super().__init__(size=size)
 
         # Canvas
         parent = self if set_parent else None
-        self.plot = PlotTsdFrame(data, index=index, parent=parent)
+        self.plot = PlotTsdFrame(data, index=index, parent=parent, display_mode=display_mode)
 
         # Top level menu container
         interval_sets = expand_with_time_support(data.time_support, interval_sets)
@@ -146,9 +146,13 @@ class TsdFrameWidget(BaseWidget):
 
         # Add custom menu items
         self.button_container.action_menu.addSeparator()
-        xvy_action = self.button_container.action_menu.addAction("Plot x vs y")
-        xvy_action.setObjectName("x_vs_y")
-        xvy_action.triggered.connect(self.button_container._popup_menu)
+        for action_name, object_name, func in [
+            ("Plot x vs y", "x_vs_y", self.button_container._popup_menu),
+            ("Toogle display mode (m)", "heatmap", self.button_container._popup_menu),
+        ]:
+            action = self.button_container.action_menu.addAction(action_name)
+            action.setObjectName(object_name)
+            action.triggered.connect(func)
 
         # Add overlay and canvas to layout
         self.layout.addWidget(self.button_container, 0)

--- a/src/pynaviz/threads/data_streaming.py
+++ b/src/pynaviz/threads/data_streaming.py
@@ -19,6 +19,8 @@ class TsdFrameStreaming:
         A function that receives a slice object indicating the time window to display.
     window_size : float
         The size of the time window (in same units as TsdFrame timestamps).
+        Window_size determines the base resolution of the streaming. The class will attempt to
+        maintain a window of this size, adjusting the slice as the user pans or zooms.
     """
 
     def __init__(self, data: nap.TsdFrame, callback: Callable[[slice], None], window_size: float):
@@ -89,8 +91,6 @@ class TsdFrameStreaming:
             Additional arguments passed to the callback (not used in this base class).
         """
         new_slice_ = self.get_slice(position[0] - width / 2, position[0] + width / 2)
-
-        # print(self._slice_, new_slice_)
 
         if new_slice_ == self._slice_:
             if not self._flushed:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -4,7 +4,7 @@ import numpy as np
 import pygfx
 import pytest
 from pygfx import cameras, controllers, renderers
-from wgpu.gui.offscreen import WgpuCanvas
+from rendercanvas.offscreen import RenderCanvas
 
 from pynaviz.controller import SpanController
 from pynaviz.synchronization_rules import _match_pan_on_x_axis, _match_zoom_on_x_axis
@@ -50,7 +50,7 @@ class TestPynaVizController:
     )
     def test_init_controller_id(self, ctrl_id, expectation):
         camera = pygfx.OrthographicCamera()
-        canvas = WgpuCanvas()
+        canvas = RenderCanvas()
         renderer = renderers.WgpuRenderer(canvas)
         try:
             with expectation:
@@ -71,7 +71,7 @@ class TestPynaVizController:
     )
     def test_init_sync_func_dict(self, dict_sync, expectation):
         camera = pygfx.OrthographicCamera()
-        canvas = WgpuCanvas()
+        canvas = RenderCanvas()
         renderer = renderers.WgpuRenderer(canvas)
         try:
             with expectation:
@@ -81,7 +81,7 @@ class TestPynaVizController:
 
     def test_control_id_setter(self):
         camera = pygfx.OrthographicCamera()
-        canvas = WgpuCanvas()
+        canvas = RenderCanvas()
         renderer = renderers.WgpuRenderer(canvas)
         try:
             ctrl = SpanController(camera, renderer=renderer, controller_id=None)
@@ -95,7 +95,7 @@ class TestPynaVizController:
     @pytest.mark.parametrize("auto_update", [True, False])
     def test_request_draw(self, auto_update):
         camera = pygfx.OrthographicCamera()
-        canvas = WgpuCanvas()
+        canvas = RenderCanvas()
         renderer = renderers.WgpuRenderer(canvas)
         try:
             ctrl = SpanController(camera, auto_update=auto_update, renderer=renderer, controller_id=None)
@@ -113,7 +113,7 @@ class TestPynaVizController:
     )
     def test_update_event(self, update_type, kwargs):
         camera = pygfx.OrthographicCamera()
-        canvas = WgpuCanvas()
+        canvas = RenderCanvas()
         renderer = renderers.WgpuRenderer(canvas)
         try:
             ctrl = SpanController(camera, renderer=renderer)
@@ -124,7 +124,7 @@ class TestPynaVizController:
 
     def test_update_zoom(self):
         camera = pygfx.OrthographicCamera()
-        canvas = WgpuCanvas()
+        canvas = RenderCanvas()
         renderer = renderers.WgpuRenderer(canvas)
         try:
             ctrl = SpanController(camera, renderer=renderer)
@@ -134,7 +134,7 @@ class TestPynaVizController:
 
     def test_update_zoom_to_point(self):
         camera = pygfx.OrthographicCamera()
-        canvas = WgpuCanvas()
+        canvas = RenderCanvas()
         renderer = renderers.WgpuRenderer(canvas)
         try:
             ctrl = SpanController(camera, renderer=renderer)
@@ -144,7 +144,7 @@ class TestPynaVizController:
 
     def test_update_pan(self):
         camera = pygfx.OrthographicCamera()
-        canvas = WgpuCanvas()
+        canvas = RenderCanvas()
         renderer = renderers.WgpuRenderer(canvas)
         try:
             ctrl = SpanController(camera, renderer=renderer)
@@ -163,7 +163,7 @@ class TestPynaVizController:
     )
     def test_sync_pan(self, update_dict, expectation, event_pan_update):
         camera = pygfx.OrthographicCamera()
-        canvas = WgpuCanvas()
+        canvas = RenderCanvas()
         renderer = renderers.WgpuRenderer(canvas)
         try:
             ctrl = SpanController(camera, renderer=renderer, dict_sync_funcs=update_dict)
@@ -183,7 +183,7 @@ class TestPynaVizController:
     )
     def test_sync_zoom(self, update_dict, expectation, event_zoom_update):
         camera = pygfx.OrthographicCamera()
-        canvas = WgpuCanvas()
+        canvas = RenderCanvas()
         renderer = renderers.WgpuRenderer(canvas)
         try:
             ctrl = SpanController(camera, renderer=renderer, dict_sync_funcs=update_dict)
@@ -203,7 +203,7 @@ class TestPynaVizController:
     )
     def test_sync_zoom_to_point(self, update_dict, expectation, event_zoom_to_point_update):
         camera = pygfx.OrthographicCamera()
-        canvas = WgpuCanvas()
+        canvas = RenderCanvas()
         renderer = renderers.WgpuRenderer(canvas)
         try:
             ctrl = SpanController(camera, renderer=renderer, dict_sync_funcs=update_dict)

--- a/tests/test_plot_tsdframe.py
+++ b/tests/test_plot_tsdframe.py
@@ -3,6 +3,7 @@ Test for PlotTsdFrame
 """
 import pathlib
 import sys
+from types import SimpleNamespace
 
 import numpy as np
 import pygfx as gfx
@@ -30,42 +31,44 @@ def test_plot_tsdframe_init(dummy_tsdframe):
     assert isinstance(v.graphic, gfx.Line)
     v.close()
 
-    assert hasattr(v, "_stream")
+    assert hasattr(v._modes["lines"], "stream")
 
 def test_plot_tsdframe_flush(dummy_tsdframe):
     v = viz.PlotTsdFrame(dummy_tsdframe)
+    mode = v._modes["lines"]
+    max_n = mode.stream._max_n
 
     # Check that the init flushed the data
     pos = v.graphic.geometry.positions.data
-    for col, start in zip(range(5), range(0, 5000, 1000)):
-        sl = slice(start + col, start + col + 1000)
+    for i, c in enumerate(dummy_tsdframe.columns):
+        sl = mode._buffer_slices[c]
         np.testing.assert_almost_equal(
-            pos[sl, 0], dummy_tsdframe.t[0:1000].astype("float32")
+            pos[sl, 0], dummy_tsdframe.t[0:max_n].astype("float32")
         )
         np.testing.assert_almost_equal(
-            pos[sl, 1], dummy_tsdframe.d[0:1000, col].astype("float32")
-        )
-
-    # Flush the same slice
-    v._flush()
-    for col, start in zip(range(5), range(0, 5000, 1000)):
-        sl = slice(start + col, start + col + 1000)
-        np.testing.assert_almost_equal(
-            pos[sl, 0], dummy_tsdframe.t[0:1000].astype("float32")
-        )
-        np.testing.assert_almost_equal(
-            pos[sl, 1], dummy_tsdframe.d[0:1000, col].astype("float32")
+            pos[sl, 1], dummy_tsdframe.d[0:max_n, i].astype("float32")
         )
 
-    # Flush a different slice
-    v._flush(dummy_tsdframe.get_slice(1, 1.5))
-    for col, start in zip(range(5), range(0, 5000, 1000)):
-        sl = slice(start + col, start + col + 1000)
+    # Flush the same range
+    v._flush(start=0, end=1)
+    for i, c in enumerate(dummy_tsdframe.columns):
+        sl = mode._buffer_slices[c]
         np.testing.assert_almost_equal(
-            pos[sl, 0], dummy_tsdframe.t[0:1000].astype("float32")
+            pos[sl, 0], dummy_tsdframe.t[0:max_n].astype("float32")
         )
         np.testing.assert_almost_equal(
-            pos[sl, 1], dummy_tsdframe.d[0:1000, col].astype("float32")
+            pos[sl, 1], dummy_tsdframe.d[0:max_n, i].astype("float32")
+        )
+
+    # Flush a different range (all data fits in memory, buffer unchanged)
+    v._flush(start=1, end=1.5)
+    for i, c in enumerate(dummy_tsdframe.columns):
+        sl = mode._buffer_slices[c]
+        np.testing.assert_almost_equal(
+            pos[sl, 0], dummy_tsdframe.t[0:max_n].astype("float32")
+        )
+        np.testing.assert_almost_equal(
+            pos[sl, 1], dummy_tsdframe.d[0:max_n, i].astype("float32")
         )
 
     v.close()
@@ -78,24 +81,25 @@ def test_plot_tsdframe_flush(dummy_tsdframe):
 )
 def test_plot_tsdframe_large(dummy_tsdframe, window):
     v = viz.PlotTsdFrame(dummy_tsdframe, window_size=2.0)
+    mode = v._modes["lines"]
 
     # ws = 2 second -> max_n = 201
-    assert v._stream._max_n == 201
-    start, end = window
+    assert mode.stream._max_n == 201
+    win_start, win_end = window
 
-    sl = dummy_tsdframe._get_slice(start, end, n_points=int(v._stream._max_n))
-    v._flush(sl)
+    v._flush(start=win_start, end=win_end)
+    sl = mode.stream.get_slice(win_start, win_end)
 
     pos = v.graphic.geometry.positions.data
-    for col, start in zip(range(5), range(0, 1000, 200)):
-        sl2 = slice(start + 2*col, start + 2*col + 200 + 1)
-        x = pos[sl2, 0]
+    for i, c in enumerate(dummy_tsdframe.columns):
+        bsl = mode._buffer_slices[c]
+        x = pos[bsl, 0]
         np.testing.assert_almost_equal(
             x[~np.isnan(x)], dummy_tsdframe.t[sl].astype("float32")
         )
-        y = pos[sl2, 1]
+        y = pos[bsl, 1]
         np.testing.assert_almost_equal(
-            y[~np.isnan(y)], dummy_tsdframe.d[sl, col].astype("float32")
+            y[~np.isnan(y)], dummy_tsdframe.d[sl, i].astype("float32")
         )
 
     v.close()
@@ -135,4 +139,314 @@ def test_plot_tsdframe_action(dummy_tsdframe, func, kwargs):
         pathlib.Path(__file__).parent / "screenshots" / filename
     ).convert("RGBA")
     np.allclose(np.array(image), image_data)
+    v.close()
+
+
+# ── LinesMode tests ──────────────────────────────────────────────────────────
+
+def test_lines_mode_buffer_layout(dummy_tsdframe):
+    v = viz.PlotTsdFrame(dummy_tsdframe)
+    mode = v._modes["lines"]
+    n_cols = dummy_tsdframe.shape[1]
+    max_n = mode.stream._max_n
+
+    # Buffer has (max_n + 1) * n_channels rows, 3 columns (x, y, z)
+    assert mode.buffer.shape == ((max_n + 1) * n_cols, 3)
+
+    # Each channel slice has exactly max_n entries
+    assert len(mode._buffer_slices) == n_cols
+    for c in dummy_tsdframe.columns:
+        sl = mode._buffer_slices[c]
+        assert sl.stop - sl.start == max_n
+
+    # NaN gaps between channels (the row right after each slice)
+    for c in dummy_tsdframe.columns:
+        sl = mode._buffer_slices[c]
+        assert np.isnan(mode.buffer[sl.stop, 0])
+
+    v.close()
+
+
+def test_lines_mode_get_callbacks(dummy_tsdframe):
+    # All data fits — no streaming callback needed
+    v = viz.PlotTsdFrame(dummy_tsdframe)
+    mode = v._modes["lines"]
+    assert mode.stream._max_n >= dummy_tsdframe.shape[0]
+    assert mode.get_callbacks() == []
+    v.close()
+
+    # Streaming needed
+    v2 = viz.PlotTsdFrame(dummy_tsdframe, window_size=2.0)
+    mode2 = v2._modes["lines"]
+    assert mode2.stream._max_n < dummy_tsdframe.shape[0]
+    callbacks = mode2.get_callbacks()
+    assert len(callbacks) == 1
+    assert callbacks[0] == mode2.stream.stream
+    v2.close()
+
+
+def test_lines_mode_rescale(dummy_tsdframe):
+    v = viz.PlotTsdFrame(dummy_tsdframe)
+    mode = v._modes["lines"]
+
+    # Before sorting: rescale should return False
+    assert mode.rescale("i") is False
+
+    # Sort, then rescale
+    v.sort_by("channel")
+    buf_before = mode.buffer[:, 1].copy()
+    result = mode.rescale("i")
+    assert result is True
+    # Buffer y-values should have changed
+    assert not np.allclose(mode.buffer[:, 1], buf_before, equal_nan=True)
+
+    v.close()
+
+
+def test_lines_mode_update_visibility(dummy_tsdframe):
+    v = viz.PlotTsdFrame(dummy_tsdframe)
+    mode = v._modes["lines"]
+
+    # All channels visible initially
+    colors = mode.graphic.geometry.colors.data
+    for _, sl in mode._buffer_slices.items():
+        assert np.all(colors[sl, -1] == 1.0)
+
+    # Hide first channel
+    vis = v._manager.visible.copy()
+    vis[0] = False
+    v._manager.visible = vis
+    mode.update_visibility()
+
+    colors = mode.graphic.geometry.colors.data
+    first_col = dummy_tsdframe.columns[0]
+    sl = mode._buffer_slices[first_col]
+    assert np.all(colors[sl, -1] == 0.0)
+
+    # Other channels still visible
+    for c in dummy_tsdframe.columns[1:]:
+        sl = mode._buffer_slices[c]
+        assert np.all(colors[sl, -1] == 1.0)
+
+    v.close()
+
+
+# ── ImageMode tests ──────────────────────────────────────────────────────────
+
+def test_image_mode_init(dummy_tsdframe):
+    v = viz.PlotTsdFrame(dummy_tsdframe, display_mode="image")
+    mode = v._modes["image"]
+
+    assert isinstance(v.graphic, gfx.Image)
+    assert mode.buffer.shape[0] == dummy_tsdframe.shape[1]
+    assert hasattr(mode, "texture")
+    assert mode._n_visible == dummy_tsdframe.shape[1]
+    assert isinstance(v.controller, viz.controller.SpanYLockController)
+
+    v.close()
+
+
+def test_image_mode_flush(dummy_tsdframe):
+    v = viz.PlotTsdFrame(dummy_tsdframe, display_mode="image")
+    mode = v._modes["image"]
+
+    # Buffer should have data (not all zeros after flush)
+    assert not np.all(mode.buffer == 0)
+
+    # Time alignment
+    assert mode.graphic.local.x == pytest.approx(float(dummy_tsdframe.t[0]))
+
+    # Buffer rows match data channels (all-data path, no reorder since unsorted)
+    n = min(dummy_tsdframe.shape[0], mode.stream._max_n)
+    for i in range(dummy_tsdframe.shape[1]):
+        np.testing.assert_almost_equal(
+            mode.buffer[i, :n],
+            dummy_tsdframe.d[:n, i].astype("float32"),
+        )
+
+    v.close()
+
+
+def test_image_mode_rescale(dummy_tsdframe):
+    v = viz.PlotTsdFrame(dummy_tsdframe, display_mode="image")
+    mode = v._modes["image"]
+
+    mode.graphic.material.clim = (-1, 1)
+
+    # Narrow (increase)
+    mode.rescale("i")
+    lo, hi = mode.graphic.material.clim
+    assert lo > -1 and hi < 1
+
+    # Reset and widen (decrease)
+    mode.graphic.material.clim = (-1, 1)
+    mode.rescale("d")
+    lo, hi = mode.graphic.material.clim
+    assert lo < -1 and hi > 1
+
+    v.close()
+
+
+def test_image_mode_color_by(dummy_tsdframe):
+    v = viz.PlotTsdFrame(dummy_tsdframe, display_mode="image")
+    mode = v._modes["image"]
+
+    mode.color_by("plasma", "test", 0, 10, lambda vals: None, {})
+    assert mode.graphic.material.map == gfx.cm.plasma
+    lo, hi = mode.graphic.material.clim
+    assert lo == 0 and hi == 10
+
+    v.close()
+
+
+def test_image_mode_visibility(dummy_tsdframe):
+    v = viz.PlotTsdFrame(dummy_tsdframe, display_mode="image")
+    mode = v._modes["image"]
+    n_channels = dummy_tsdframe.shape[1]
+
+    assert mode._n_visible == n_channels
+
+    # Hide first channel
+    vis = v._manager.visible.copy()
+    vis[0] = False
+    v._manager.visible = vis
+    mode.update_visibility()
+
+    assert mode._n_visible == n_channels - 1
+    assert mode.texture.data.shape[0] == n_channels - 1
+
+    v.close()
+
+
+def test_image_mode_reorder_rows(dummy_tsdframe):
+    v = viz.PlotTsdFrame(dummy_tsdframe, display_mode="image")
+    mode = v._modes["image"]
+    n_cols = dummy_tsdframe.shape[1]
+
+    # No reorder when not sorted
+    raw = np.arange(n_cols * 10, dtype="float32").reshape(n_cols, 10)
+    result = mode._reorder_image_rows(raw)
+    np.testing.assert_array_equal(result, raw)
+
+    # Sort, then reorder should permute rows
+    v.sort_by("channel")
+    result = mode._reorder_image_rows(raw)
+    offsets = np.array([
+        v._manager.data.loc[c]["offset"] for c in dummy_tsdframe.columns
+    ])
+    order = np.argsort(offsets)
+    np.testing.assert_array_equal(result, raw[order])
+
+    v.close()
+
+
+def test_image_mode_get_visible_buffer(dummy_tsdframe):
+    v = viz.PlotTsdFrame(dummy_tsdframe, display_mode="image")
+    mode = v._modes["image"]
+
+    # All visible: returns full buffer
+    visible_buf = mode._get_visible_buffer()
+    assert visible_buf.shape[0] == dummy_tsdframe.shape[1]
+
+    # Hide one channel
+    vis = v._manager.visible.copy()
+    vis[0] = False
+    v._manager.visible = vis
+    visible_buf = mode._get_visible_buffer()
+    assert visible_buf.shape[0] == dummy_tsdframe.shape[1] - 1
+
+    v.close()
+
+
+# ── XvsYMode tests ───────────────────────────────────────────────────────────
+
+def test_xvsy_mode_init(dummy_tsdframe):
+    v = viz.PlotTsdFrame(dummy_tsdframe)
+    v.plot_x_vs_y(x_col=0, y_col=1)
+    mode = v._modes["x_vs_y"]
+
+    assert isinstance(mode.graphic, gfx.Line)
+    assert isinstance(mode.time_point, gfx.Points)
+    assert mode.buffer.shape == (len(dummy_tsdframe), 3)
+
+    # Buffer x/y match the two selected columns
+    np.testing.assert_almost_equal(
+        mode.buffer[:, 0], dummy_tsdframe.d[:, 0].astype("float32")
+    )
+    np.testing.assert_almost_equal(
+        mode.buffer[:, 1], dummy_tsdframe.d[:, 1].astype("float32")
+    )
+
+    # Time point rendered above the line (z = 1)
+    assert mode.time_point.geometry.positions.data[0, 2] == 1.0
+
+    v.close()
+
+
+def test_xvsy_mode_update_parameters(dummy_tsdframe):
+    v = viz.PlotTsdFrame(dummy_tsdframe)
+    mode = v._modes["x_vs_y"]
+
+    mode.update_parameters(x_col=2, y_col=3, color="blue", thickness=3.0, markersize=20.0)
+    assert mode.x_col == 2
+    assert mode.y_col == 3
+    assert mode.color == "blue"
+    assert mode.thickness == 3.0
+    assert mode.markersize == 20.0
+
+    v.close()
+
+
+def test_xvsy_mode_update_buffer(dummy_tsdframe):
+    v = viz.PlotTsdFrame(dummy_tsdframe)
+    v.plot_x_vs_y(x_col=0, y_col=1)
+    mode = v._modes["x_vs_y"]
+
+    # Move to frame 50
+    mode._update_buffer(50)
+    marker = mode.time_point.geometry.positions.data[0]
+    line = mode.graphic.geometry.positions.data[50]
+    np.testing.assert_almost_equal(marker[0:2], line[0:2])
+
+    # Move to frame 100
+    mode._update_buffer(100)
+    marker = mode.time_point.geometry.positions.data[0]
+    line = mode.graphic.geometry.positions.data[100]
+    np.testing.assert_almost_equal(marker[0:2], line[0:2])
+
+    v.close()
+
+
+def test_xvsy_mode_get_callbacks(dummy_tsdframe):
+    v = viz.PlotTsdFrame(dummy_tsdframe)
+    mode = v._modes["x_vs_y"]
+    callbacks = mode.get_callbacks()
+    assert len(callbacks) == 1
+    assert callbacks[0] == mode._update_buffer
+
+    v.close()
+
+
+# ── Mode switching ───────────────────────────────────────────────────────────
+
+def test_toggle_display_mode(dummy_tsdframe):
+    v = viz.PlotTsdFrame(dummy_tsdframe)
+
+    # Starts in lines mode
+    assert v._display_mode == "lines"
+    assert isinstance(v.graphic, gfx.Line)
+
+    # Toggle to image
+    v._toggle_display_mode(SimpleNamespace(type="key_down", key="m"))
+    assert v._display_mode == "image"
+    assert isinstance(v.graphic, gfx.Image)
+    assert isinstance(v.controller, viz.controller.SpanYLockController)
+
+    # Toggle back to lines
+    v._toggle_display_mode(SimpleNamespace(type="key_down", key="m"))
+    assert v._display_mode == "lines"
+    assert isinstance(v.graphic, gfx.Line)
+    assert not isinstance(v.controller, viz.controller.SpanYLockController)
+    assert isinstance(v.controller, viz.controller.SpanController)
+
     v.close()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,12 @@
 from typing import Callable
 
 from pygfx import renderers
-from wgpu.gui.offscreen import WgpuCanvas
+from rendercanvas.offscreen import RenderCanvas
 
 
 def test_get_event_handle():
     from pynaviz.utils import _get_event_handle
-    canvas = WgpuCanvas()
+    canvas = RenderCanvas()
     renderer = renderers.WgpuRenderer(canvas)
     try:
         func = _get_event_handle(renderer)


### PR DESCRIPTION
This pull request introduces several enhancements and improvements across the codebase, including new display mode functionality for plots, improved menu handling, documentation updates, and test refactoring. The most significant changes are the addition of a heatmap display toggle in the plot widget and the replacement of `WgpuCanvas` with `RenderCanvas` in tests for better modularity.

### Plot display mode and menu enhancements

* Added a `display_mode` parameter to `TsdFrameWidget` and `PlotTsdFrame`, allowing plots to be initialized with different display modes (e.g., "lines" or "heatmap"). Also, extended the action menu to include a "Toggle display mode (m)" option. (`src/pynaviz/qt/widget_plot.py`)
* Updated menu handling to support toggling the heatmap display mode by simulating a key press event when the "heatmap" menu item is selected. (`src/pynaviz/qt/widget_menu.py`) [[1]](diffhunk://#diff-93c8f59958f855e626078452c348b66f5649b1400f6529b67a2612a012ba0000R448-R450) [[2]](diffhunk://#diff-93c8f59958f855e626078452c348b66f5649b1400f6529b67a2612a012ba0000R15)

### Documentation and streaming improvements

* Clarified the role of `window_size` in `TsdFrameStreaming` by updating the docstring to explain its effect on streaming resolution and window management. (`src/pynaviz/threads/data_streaming.py`)
* Cleaned up the `stream` method by removing commented-out debug code for better readability. (`src/pynaviz/threads/data_streaming.py`)

### Test refactoring

* Replaced `WgpuCanvas` with `RenderCanvas` in all tests to improve modularity and compatibility, updating imports and usage throughout `tests/test_controller.py` and `tests/test_utils.py`. [[1]](diffhunk://#diff-f7dbf2e52de217bf88ebb0364a5529e8f303b44ed043c4c3e4a1a1d681588ea4L7-R7) [[2]](diffhunk://#diff-f7dbf2e52de217bf88ebb0364a5529e8f303b44ed043c4c3e4a1a1d681588ea4L53-R53) [[3]](diffhunk://#diff-f7dbf2e52de217bf88ebb0364a5529e8f303b44ed043c4c3e4a1a1d681588ea4L74-R74) [[4]](diffhunk://#diff-f7dbf2e52de217bf88ebb0364a5529e8f303b44ed043c4c3e4a1a1d681588ea4L84-R84) [[5]](diffhunk://#diff-f7dbf2e52de217bf88ebb0364a5529e8f303b44ed043c4c3e4a1a1d681588ea4L98-R98) [[6]](diffhunk://#diff-f7dbf2e52de217bf88ebb0364a5529e8f303b44ed043c4c3e4a1a1d681588ea4L116-R116) [[7]](diffhunk://#diff-f7dbf2e52de217bf88ebb0364a5529e8f303b44ed043c4c3e4a1a1d681588ea4L127-R127) [[8]](diffhunk://#diff-f7dbf2e52de217bf88ebb0364a5529e8f303b44ed043c4c3e4a1a1d681588ea4L137-R137) [[9]](diffhunk://#diff-f7dbf2e52de217bf88ebb0364a5529e8f303b44ed043c4c3e4a1a1d681588ea4L147-R147) [[10]](diffhunk://#diff-f7dbf2e52de217bf88ebb0364a5529e8f303b44ed043c4c3e4a1a1d681588ea4L166-R166) [[11]](diffhunk://#diff-f7dbf2e52de217bf88ebb0364a5529e8f303b44ed043c4c3e4a1a1d681588ea4L186-R186) [[12]](diffhunk://#diff-f7dbf2e52de217bf88ebb0364a5529e8f303b44ed043c4c3e4a1a1d681588ea4L206-R206) [[13]](diffhunk://#diff-33c13e0b177bacd2f02e29bcb8aea5b49e7ce34901fd8f41fefb65defba1bd33L4-R9)

### Synchronization improvements

* Ensured controller synchronization by sending sync events after time-panning actions in `go_to` method. (`src/pynaviz/controller.py`)