### PR TITLE
fallback for no packet case

### DIFF
--- a/src/pynaviz/audiovideo/video_handling.py
+++ b/src/pynaviz/audiovideo/video_handling.py
@@ -634,6 +634,7 @@ class VideoHandler(BaseAudioVideo):
             self.get(0)
 
         preceding_frame = self.current_frame
+        last_frame = self.current_frame  # safe fallback if no packet yields frames
         go_to_next_packet = False
 
         while collected < num_frames:
@@ -699,9 +700,10 @@ class VideoHandler(BaseAudioVideo):
                 else:
                     go_to_next_packet = True
 
+                last_frame = frame
                 preceding_frame = frame
 
-        return indices[-1], frames, frame
+        return indices[-1], frames, last_frame
 
     def __getitem__(self, idx: slice | int) -> NDArray | av.VideoFrame | List[av.VideoFrame]:
         """

--- a/src/pynaviz/audiovideo/video_plot.py
+++ b/src/pynaviz/audiovideo/video_plot.py
@@ -5,6 +5,7 @@ Module for time-synchronized video plotting using pygfx and multiprocessing.
 
 import abc
 import atexit
+import multiprocessing
 import pathlib
 import queue
 import signal
@@ -12,11 +13,8 @@ import sys
 import threading
 import weakref
 from abc import ABC, abstractmethod
-import multiprocessing
 from multiprocessing import Event, Queue, current_process, set_start_method, shared_memory
 from multiprocessing import Lock as MultiProcessLock
-
-_mp_ctx = multiprocessing.get_context("spawn")
 from typing import Any, Optional
 
 import av
@@ -31,6 +29,9 @@ from ..utils import GRADED_COLOR_LIST
 from .skeleton_plot import PlotPoints
 from .video_handling import VideoHandler
 from .video_worker import RenderTriggerSource, video_worker_process
+
+# Enforce spawn on all platforms (avoids fork+FFmpeg segfaults on Linux)
+_mp_ctx = multiprocessing.get_context("spawn")
 
 # WeakSet to avoid keeping dead references
 _active_plot_videos = weakref.WeakSet()

--- a/src/pynaviz/audiovideo/video_plot.py
+++ b/src/pynaviz/audiovideo/video_plot.py
@@ -12,8 +12,11 @@ import sys
 import threading
 import weakref
 from abc import ABC, abstractmethod
-from multiprocessing import Event, Process, Queue, current_process, set_start_method, shared_memory
+import multiprocessing
+from multiprocessing import Event, Queue, current_process, set_start_method, shared_memory
 from multiprocessing import Lock as MultiProcessLock
+
+_mp_ctx = multiprocessing.get_context("spawn")
 from typing import Any, Optional
 
 import av
@@ -340,7 +343,7 @@ class PlotVideo(PlotBaseVideoTensor):
 
             # Worker process to read video frames asynchronously
             self.worker_lock = MultiProcessLock()
-            self._worker = Process(
+            self._worker = _mp_ctx.Process(
                 target=video_worker_process,
                 args=(
                     video_path,

--- a/tests/test_video_worker.py
+++ b/tests/test_video_worker.py
@@ -1,6 +1,8 @@
-import multiprocessing as mp
 import queue
-from multiprocessing import Event, Lock, Queue, shared_memory
+from multiprocessing import shared_memory
+
+import multiprocessing as mp
+_mp_ctx = mp.get_context("spawn")
 
 import numpy as np
 import pytest
@@ -91,11 +93,11 @@ def mp_primitives():
     Creates multiprocessing communication primitives.
     """
     return {
-        'request_queue': Queue(),
-        'response_queue': Queue(),
-        'frame_ready': Event(),
-        'stop_event': Event(),
-        'buffer_lock': Lock(),
+        'request_queue': _mp_ctx.Queue(),
+        'response_queue': _mp_ctx.Queue(),
+        'frame_ready': _mp_ctx.Event(),
+        'stop_event': _mp_ctx.Event(),
+        'buffer_lock': _mp_ctx.Lock(),
     }
 
 
@@ -121,7 +123,7 @@ def test_worker_starts_and_stops_cleanly(
     print(f"Using video: {video_config['video_path']}")
 
     # Start the worker process
-    process = mp.Process(
+    process = _mp_ctx.Process(
         target=video_worker_process,
         args=(
             video_config['video_path'],
@@ -208,7 +210,7 @@ def test_worker_processes_frame_request(
     print(f"\n=== TEST 2: Process Frame Request (trigger={trigger_source}) ===")
 
     # Start worker
-    process = mp.Process(
+    process = _mp_ctx.Process(
         target=video_worker_process,
         args=(
             video_config['video_path'],
@@ -326,7 +328,7 @@ def test_worker_processes_frame_last_request(
     print(f"\n=== TEST 2: Process Frame Request (trigger={trigger_source}) ===")
 
     # Start worker
-    process = mp.Process(
+    process = _mp_ctx.Process(
         target=video_worker_process,
         args=(
             video_config['video_path'],

--- a/tests/test_video_worker.py
+++ b/tests/test_video_worker.py
@@ -236,8 +236,8 @@ def test_worker_processes_frame_request(
         print(f"Requesting frame at index {requested_idx}")
         mp_primitives['request_queue'].put((requested_idx, move_key_frame, trigger_source))
 
-        # Wait for frame_ready event (max 2 seconds)
-        is_ready = mp_primitives['frame_ready'].wait(timeout=2.0)
+        # Wait for frame_ready event (longer timeout needed with spawn start method)
+        is_ready = mp_primitives['frame_ready'].wait(timeout=15.0)
         assert is_ready, "frame_ready Event should be set within timeout"
         print("✓ frame_ready Event was set")
 
@@ -355,8 +355,8 @@ def test_worker_processes_frame_last_request(
         for i in [3, 2, 1, 0]:
             mp_primitives['request_queue'].put((requested_idx - i, move_key_frame, trigger_source))
 
-        # Wait for frame_ready event (max 2 seconds)
-        is_ready = mp_primitives['frame_ready'].wait(timeout=2.0)
+        # Wait for frame_ready event (longer timeout needed with spawn start method)
+        is_ready = mp_primitives['frame_ready'].wait(timeout=15.0)
         assert is_ready, "frame_ready Event should be set within timeout"
         print("✓ frame_ready Event was set")
 

--- a/tests/test_video_worker.py
+++ b/tests/test_video_worker.py
@@ -1,9 +1,6 @@
+import multiprocessing as mp
 import queue
 from multiprocessing import shared_memory
-
-import multiprocessing as mp
-# Enforce spawn for linux too (consistent with macOS and windows)
-_mp_ctx = mp.get_context("spawn")
 
 import numpy as np
 import pytest
@@ -11,6 +8,8 @@ import pytest
 from pynaviz.audiovideo.video_worker import video_worker_process
 from pynaviz.utils import RenderTriggerSource
 
+# Enforce spawn for linux too (consistent with macOS and windows)
+_mp_ctx = mp.get_context("spawn")
 
 @pytest.fixture
 def test_video_path():

--- a/tests/test_video_worker.py
+++ b/tests/test_video_worker.py
@@ -2,6 +2,7 @@ import queue
 from multiprocessing import shared_memory
 
 import multiprocessing as mp
+# Enforce spawn for linux too (consistent with macOS and windows)
 _mp_ctx = mp.get_context("spawn")
 
 import numpy as np

--- a/tests/test_video_worker.py
+++ b/tests/test_video_worker.py
@@ -152,8 +152,8 @@ def test_worker_starts_and_stops_cleanly(
             mp_primitives['stop_event'].set()
             print("✓ Shutdown signal sent")
 
-        # Wait for process to finish (max 2 seconds)
-        process.join(timeout=2.0)
+        # Wait for process to finish (max 10 seconds)
+        process.join(timeout=10.0)
 
         # Verify it stopped
         assert not process.is_alive(), "Worker should stop after shutdown signal"
@@ -285,7 +285,7 @@ def test_worker_processes_frame_request(
     finally:
         # Shutdown
         mp_primitives['request_queue'].put((None, None, None))
-        process.join(timeout=2.0)
+        process.join(timeout=10.0)
         if process.is_alive():
             process.terminate()
             process.join()
@@ -396,7 +396,7 @@ def test_worker_processes_frame_last_request(
     finally:
         # Shutdown
         mp_primitives['request_queue'].put((None, None, None))
-        process.join(timeout=2.0)
+        process.join(timeout=10.0)
         if process.is_alive():
             process.terminate()
             process.join()


### PR DESCRIPTION

## Changes

- Minor safety change making sure that `last_frame` is always defined in `_decode_multiple` guarding against empty videos. 
- Force `spawn` when calling multiprocessing. This is the default for mac and windows (fresh python process is launched, slower but safer) but it was not the case for Linux. In the CI, this resulted in flaky worker shutdowns, and the worker was segfaulting at times. The most likely cause was the FFMPEG state from previous tests leaking into a forked process. Forcing the spawn fixed the test.

