### PR TITLE
Dialog layout fixes

### DIFF
--- a/src/pynaviz/qt/drop_down_dict_builder.py
+++ b/src/pynaviz/qt/drop_down_dict_builder.py
@@ -1,11 +1,60 @@
-import bisect
 from collections import OrderedDict
 
 import matplotlib.pyplot as plt
-from PySide6.QtGui import QAction
+import numpy as np
+from PySide6.QtCore import QSize
+from PySide6.QtGui import QAction, QColor, QImage, QPixmap
 from PySide6.QtWidgets import QComboBox, QWidget
 
 from pynaviz.utils import GRADED_COLOR_LIST
+
+_CMAP_GROUPS = OrderedDict([
+    ("Perceptually Uniform", [
+        "viridis", "plasma", "inferno", "magma", "cividis",
+    ]),
+    ("Sequential", [
+        "Greys", "Purples", "Blues", "Greens", "Oranges", "Reds",
+        "YlOrBr", "YlOrRd", "OrRd", "PuRd", "RdPu", "BuPu",
+        "GnBu", "PuBu", "YlGnBu", "PuBuGn", "BuGn", "YlGn",
+        "binary", "gist_yarg", "gist_gray", "gray", "bone", "pink",
+        "spring", "summer", "autumn", "winter", "cool", "Wistia",
+        "hot", "afmhot", "gist_heat", "copper",
+    ]),
+    ("Diverging", [
+        "PiYG", "PRGn", "BrBG", "PuOr", "RdGy", "RdBu",
+        "RdYlBu", "RdYlGn", "Spectral", "coolwarm", "bwr", "seismic",
+        "berlin", "managua", "vanimo",
+    ]),
+    ("Cyclic", ["twilight", "twilight_shifted", "hsv"]),
+    ("Qualitative", [
+        "Pastel1", "Pastel2", "Paired", "Accent", "Dark2",
+        "Set1", "Set2", "Set3", "tab10", "tab20", "tab20b", "tab20c",
+    ]),
+    ("Miscellaneous", [
+        "flag", "prism", "ocean", "gist_earth", "terrain", "gist_stern",
+        "gnuplot", "gnuplot2", "CMRmap", "cubehelix", "brg", "gist_rainbow",
+        "rainbow", "jet", "turbo", "nipy_spectral", "gist_ncar",
+    ]),
+])
+
+
+def _color_icon(name: str) -> QPixmap:
+    px = QPixmap(32, 16)
+    px.fill(QColor(name))
+    return px
+
+
+def _cmap_icon(name: str, width: int = 64, height: int = 12) -> QPixmap:
+    try:
+        cmap = plt.colormaps[name]
+    except KeyError:
+        px = QPixmap(width, height)
+        px.fill(QColor("gray"))
+        return px
+    rgba = (cmap(np.linspace(0, 1, width)) * 255).astype(np.uint8)
+    rgba_2d = np.ascontiguousarray(np.tile(rgba, (height, 1, 1)))
+    img = QImage(rgba_2d.tobytes(), width, height, width * 4, QImage.Format.Format_RGBA8888)
+    return QPixmap.fromImage(img)
 
 
 def _get_meta_combo(widget):
@@ -38,13 +87,22 @@ def get_popup_kwargs(popup_name: str, widget: QWidget, action: QAction | None) -
         if meta is None:
             return
 
-        cmap_list = sorted(plt.colormaps())
-        idx = bisect.bisect_left(cmap_list, cmap)
+        # Build groups, appending any installed cmaps not in the known lists to Miscellaneous
+        registered = set(plt.colormaps())
+        known = {name for names in _CMAP_GROUPS.values() for name in names}
+        groups = OrderedDict(
+            (cat, [n for n in names if n in registered])
+            for cat, names in _CMAP_GROUPS.items()
+        )
+        groups["Miscellaneous"] += sorted(registered - known - {n + "_r" for n in known})
         parameters = {
             "type": QComboBox,
             "name": "colormap",
-            "items": cmap_list,
-            "current_index": idx,
+            "groups": groups,
+            "current_value": cmap,
+            "icon_factory": _cmap_icon,
+            "icon_size": QSize(64, 12),
+            "clear_text": True,
         }
         kwargs = dict(
             widgets=OrderedDict(Metadata=meta, Colormap=parameters),
@@ -70,6 +128,9 @@ def get_popup_kwargs(popup_name: str, widget: QWidget, action: QAction | None) -
             "name": "colors",
             "items": GRADED_COLOR_LIST,
             "current_index": 0,
+            "icon_factory": _color_icon,
+            "icon_size": QSize(32, 16),
+            "clear_text": True,
         }
         kwargs = dict(
             widgets=cols,

--- a/src/pynaviz/qt/widget_menu.py
+++ b/src/pynaviz/qt/widget_menu.py
@@ -18,7 +18,7 @@ from typing import Any, Callable
 import numpy as np
 import pynapple as nap
 from PySide6.QtCore import QPoint, QSize, Qt
-from PySide6.QtGui import QAction
+from PySide6.QtGui import QAction, QIcon, QPixmap
 from PySide6.QtWidgets import (
     QComboBox,
     QDialog,
@@ -73,17 +73,64 @@ def widget_factory(parameters: dict) -> QWidget:
         The configured widget instance.
     """
     widget_type = parameters.pop("type")
+    icon_factory = parameters.pop("icon_factory", None)
+    icon_size = parameters.pop("icon_size", QSize(16, 16))
+    clear_text = parameters.pop("clear_text", False)
+    groups = parameters.pop("groups", None)
+    current_value = parameters.pop("current_value", None)
     if widget_type == QComboBox:
         widget = QComboBox()
-        for arg_name, attr_name in WIDGET_PARAMS[QComboBox].items():
-            method = getattr(widget, attr_name, None)
-            value = parameters.get(arg_name)
-            if method and value is not None:
-                if arg_name == "values":
-                    for i, v in enumerate(value):
-                        method(i, v)
-                else:
-                    method(value)
+        if groups is not None:
+            if icon_factory is not None:
+                widget.setIconSize(icon_size)
+                widget.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon)
+                widget.setMinimumContentsLength(0)
+                widget.setMinimumWidth(icon_size.width() + 36)  # icon + padding + arrow button
+            current_index = 0
+            combo_index = 0
+            for g_idx, (group_name, group_items) in enumerate(groups.items()):
+                if g_idx > 0:
+                    widget.insertSeparator(widget.count())
+                    combo_index += 1
+                widget.addItem(group_name)
+                header = widget.model().item(widget.count() - 1)
+                header.setFlags(Qt.ItemFlag.ItemIsEnabled)
+                font = header.font()
+                font.setBold(True)
+                header.setFont(font)
+                combo_index += 1
+                for name in group_items:
+                    widget.addItem(name)
+                    if name == current_value:
+                        current_index = combo_index
+                    if icon_factory is not None:
+                        idx = widget.count() - 1
+                        widget.setItemData(idx, name)
+                        widget.setItemIcon(idx, QIcon(icon_factory(name)))
+                        if clear_text:
+                            widget.setItemText(idx, "")
+                            widget.setItemData(idx, name, Qt.ItemDataRole.ToolTipRole)
+                    combo_index += 1
+            widget.setCurrentIndex(current_index)
+        else:
+            for arg_name, attr_name in WIDGET_PARAMS[QComboBox].items():
+                method = getattr(widget, attr_name, None)
+                value = parameters.get(arg_name)
+                if method and value is not None:
+                    if arg_name == "values":
+                        for i, v in enumerate(value):
+                            method(i, v)
+                    else:
+                        method(value)
+            if icon_factory is not None:
+                widget.setIconSize(icon_size)
+                for i in range(widget.count()):
+                    text = widget.itemText(i)
+                    widget.setItemIcon(i, QIcon(icon_factory(text)))
+                    widget.setItemData(i, text)
+                    if clear_text:
+                        widget.setItemText(i, "")
+                        widget.setItemData(i, text, Qt.ItemDataRole.ToolTipRole)
     elif widget_type == QDoubleSpinBox:
         widget = QDoubleSpinBox()
         for arg_name, attr_name in WIDGET_PARAMS[QDoubleSpinBox].items():

--- a/src/pynaviz/qt/widget_menu.py
+++ b/src/pynaviz/qt/widget_menu.py
@@ -18,7 +18,7 @@ from typing import Any, Callable
 import numpy as np
 import pynapple as nap
 from PySide6.QtCore import QPoint, QSize, Qt
-from PySide6.QtGui import QAction, QIcon, QPixmap
+from PySide6.QtGui import QAction, QIcon
 from PySide6.QtWidgets import (
     QComboBox,
     QDialog,

--- a/src/pynaviz/qt/widget_menu.py
+++ b/src/pynaviz/qt/widget_menu.py
@@ -30,7 +30,6 @@ from PySide6.QtWidgets import (
     QPushButton,
     QScrollArea,
     QSizePolicy,
-    QSpacerItem,
     QStyle,
     QVBoxLayout,
     QWidget,
@@ -128,41 +127,24 @@ class DropdownDialog(QDialog):
         self.setWindowModality(Qt.WindowModality.NonModal)
 
         num_cols = min(len(widgets), 3)
-        num_rows = len(widgets) // num_cols
-        self.setFixedWidth(200 * num_cols)
-        self.setFixedHeight(min(150 * num_rows, 400))
 
         self._func = func
         self.widgets: dict[int, QWidget] = {}
 
         main_layout = QVBoxLayout(self)
+        main_layout.setContentsMargins(12, 12, 12, 12)
+        main_layout.setSpacing(8)
 
-        # Scrollable area
+        # Scrollable area (useful when there are many widgets)
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
-        scroll.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        scroll.setFrameShape(scroll.Shape.NoFrame)
         scroll_content = QWidget()
-        scroll_content.setSizePolicy(
-            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Minimum
-        )
 
-        grid_layout = QGridLayout()
-        inner_layout = QVBoxLayout()
-        inner_layout.addLayout(grid_layout)
+        grid_layout = QGridLayout(scroll_content)
+        grid_layout.setContentsMargins(4, 4, 4, 4)
+        grid_layout.setSpacing(8)
 
-        spacer = QSpacerItem(
-            0, 0, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding
-        )
-        h_spacer = QSpacerItem(
-            0, 0, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
-        )
-        inner_layout.addItem(spacer)
-
-        outer_layout = QHBoxLayout()
-        outer_layout.addLayout(inner_layout)
-        outer_layout.addItem(h_spacer)
-
-        scroll_content.setLayout(outer_layout)
         scroll.setWidget(scroll_content)
         main_layout.addWidget(scroll)
 
@@ -170,14 +152,13 @@ class DropdownDialog(QDialog):
         def make_labeled_widget(label_text: str, widget: QWidget) -> QWidget:
             label = QLabel(label_text)
             label.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
-            widget.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
+            widget.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
             wrapper = QWidget()
-            layout = QHBoxLayout()
-            layout.setContentsMargins(1, 0, 1, 0)
-            layout.setSpacing(2)
+            layout = QHBoxLayout(wrapper)
+            layout.setContentsMargins(0, 0, 0, 0)
+            layout.setSpacing(8)
             layout.addWidget(label)
             layout.addWidget(widget)
-            wrapper.setLayout(layout)
             return wrapper
 
         for i, (label, params) in enumerate(widgets.items()):

--- a/tests/test_widget_menu.py
+++ b/tests/test_widget_menu.py
@@ -1,0 +1,342 @@
+"""Tests for DropdownDialog layout, widget_factory icon/group support, and icon factories."""
+from collections import OrderedDict
+
+import pytest
+from PySide6.QtCore import QSize, Qt
+from PySide6.QtGui import QPixmap
+from PySide6.QtWidgets import QComboBox, QDoubleSpinBox
+
+from pynaviz.qt.drop_down_dict_builder import _CMAP_GROUPS, _cmap_icon, _color_icon
+from pynaviz.qt.widget_menu import DropdownDialog, widget_factory
+
+
+# ---------------------------------------------------------------------------
+# widget_factory — flat combobox
+# ---------------------------------------------------------------------------
+
+def test_widget_factory_combobox_basic(qtbot):
+    widget = widget_factory({
+        "type": QComboBox,
+        "items": ["A", "B", "C"],
+        "current_index": 1,
+    })
+    assert isinstance(widget, QComboBox)
+    assert widget.count() == 3
+    assert widget.currentIndex() == 1
+
+
+def test_widget_factory_spinbox(qtbot):
+    widget = widget_factory({
+        "type": QDoubleSpinBox,
+        "value": 3.14,
+    })
+    assert isinstance(widget, QDoubleSpinBox)
+    assert abs(widget.value() - 3.14) < 1e-6
+
+
+def test_widget_factory_unknown_type_raises(qtbot):
+    with pytest.raises(ValueError):
+        widget_factory({"type": object})
+
+
+# ---------------------------------------------------------------------------
+# widget_factory — icon_factory (flat, color swatches)
+# ---------------------------------------------------------------------------
+
+def test_widget_factory_icon_factory_sets_icons(qtbot):
+    """icon_factory is called for each item and icons are set."""
+    icons_generated = []
+
+    def fake_icon(name):
+        icons_generated.append(name)
+        px = QPixmap(8, 8)
+        return px
+
+    widget = widget_factory({
+        "type": QComboBox,
+        "items": ["red", "blue"],
+        "icon_factory": fake_icon,
+        "icon_size": QSize(8, 8),
+        "clear_text": False,
+    })
+    assert icons_generated == ["red", "blue"]
+    # Icons are set, text still visible
+    assert widget.itemText(0) == "red"
+    assert widget.itemText(1) == "blue"
+
+
+def test_widget_factory_clear_text_removes_label_and_sets_tooltip(qtbot):
+    """clear_text=True clears item text and stores name as tooltip and UserRole data."""
+    widget = widget_factory({
+        "type": QComboBox,
+        "items": ["navy", "crimson"],
+        "icon_factory": _color_icon,
+        "icon_size": QSize(32, 16),
+        "clear_text": True,
+    })
+    for i in range(widget.count()):
+        assert widget.itemText(i) == ""
+        assert widget.itemData(i) is not None           # UserRole — color name
+        assert widget.itemData(i, Qt.ItemDataRole.ToolTipRole) == widget.itemData(i)
+
+
+def test_widget_factory_clear_text_data_survives(qtbot):
+    """After clearing text, currentData() still returns the original color name."""
+    widget = widget_factory({
+        "type": QComboBox,
+        "items": ["navy", "crimson"],
+        "icon_factory": _color_icon,
+        "icon_size": QSize(32, 16),
+        "clear_text": True,
+    })
+    widget.setCurrentIndex(0)
+    assert widget.currentData() == "navy"
+    widget.setCurrentIndex(1)
+    assert widget.currentData() == "crimson"
+
+
+# ---------------------------------------------------------------------------
+# widget_factory — grouped combobox
+# ---------------------------------------------------------------------------
+
+def test_widget_factory_groups_builds_headers(qtbot):
+    """Group headers are non-selectable; separators exist between groups."""
+    groups = OrderedDict([
+        ("GroupA", ["a1", "a2"]),
+        ("GroupB", ["b1"]),
+    ])
+    widget = widget_factory({
+        "type": QComboBox,
+        "groups": groups,
+        "current_value": "b1",
+    })
+    # Total items: header + 2 items + separator + header + 1 item = 6
+    assert widget.count() == 6
+
+    # First item is the "GroupA" header — not selectable
+    header_item = widget.model().item(0)
+    assert not (header_item.flags() & Qt.ItemFlag.ItemIsSelectable)
+    assert header_item.font().bold()
+
+    # current_value="b1" lands on the correct index
+    assert widget.currentText() == "b1"
+
+
+def test_widget_factory_groups_current_value_default(qtbot):
+    """When current_value is not found, index defaults to 0 (first header)."""
+    groups = OrderedDict([("G", ["x", "y"])])
+    widget = widget_factory({
+        "type": QComboBox,
+        "groups": groups,
+        "current_value": "nonexistent",
+    })
+    assert widget.currentIndex() == 0
+
+
+def test_widget_factory_groups_with_icon_factory(qtbot):
+    """Icons and tooltips are set for group items; headers have no icon."""
+    called = []
+
+    def fake_icon(name):
+        called.append(name)
+        return QPixmap(4, 4)
+
+    groups = OrderedDict([("G", ["red", "blue"])])
+    widget = widget_factory({
+        "type": QComboBox,
+        "groups": groups,
+        "icon_factory": fake_icon,
+        "icon_size": QSize(4, 4),
+        "clear_text": True,
+        "current_value": "red",
+    })
+    assert set(called) == {"red", "blue"}
+    # Items have data (UserRole) and tooltip set
+    # Index 0 = header "G", index 1 = "red", index 2 = "blue"
+    assert widget.itemData(1) == "red"
+    assert widget.itemData(1, Qt.ItemDataRole.ToolTipRole) == "red"
+    assert widget.itemData(2) == "blue"
+
+
+# ---------------------------------------------------------------------------
+# _color_icon
+# ---------------------------------------------------------------------------
+
+def test_color_icon_returns_pixmap(qtbot):
+    px = _color_icon("navy")
+    assert isinstance(px, QPixmap)
+    assert not px.isNull()
+    assert px.width() == 32 and px.height() == 16
+
+
+def test_color_icon_fill(qtbot):
+    """The pixmap is filled with the requested colour (sample centre pixel)."""
+    from PySide6.QtGui import QColor
+    px = _color_icon("red")
+    img = px.toImage()
+    center = img.pixelColor(16, 8)
+    assert center.red() > 200
+    assert center.blue() < 50
+
+
+# ---------------------------------------------------------------------------
+# _cmap_icon
+# ---------------------------------------------------------------------------
+
+def test_cmap_icon_returns_pixmap(qtbot):
+    px = _cmap_icon("viridis")
+    assert isinstance(px, QPixmap)
+    assert not px.isNull()
+    assert px.width() == 64 and px.height() == 12
+
+
+def test_cmap_icon_unknown_cmap_returns_gray(qtbot):
+    """Unknown cmap name returns a gray fallback pixmap."""
+    from PySide6.QtGui import QColor
+    px = _cmap_icon("__not_a_real_cmap__")
+    assert not px.isNull()
+    img = px.toImage()
+    c = img.pixelColor(32, 6)
+    assert c == QColor("gray")
+
+
+def test_cmap_icon_gradient_varies(qtbot):
+    """Left and right ends of a gradient pixmap have different colours."""
+    px = _cmap_icon("viridis")
+    img = px.toImage()
+    left = img.pixelColor(2, 6)
+    right = img.pixelColor(61, 6)
+    assert left != right
+
+
+# ---------------------------------------------------------------------------
+# _CMAP_GROUPS
+# ---------------------------------------------------------------------------
+
+def test_cmap_groups_no_duplicates():
+    all_names = [n for names in _CMAP_GROUPS.values() for n in names]
+    assert len(all_names) == len(set(all_names)), "Duplicate cmap names in _CMAP_GROUPS"
+
+
+def test_cmap_groups_known_categories():
+    assert "Perceptually Uniform" in _CMAP_GROUPS
+    assert "Sequential" in _CMAP_GROUPS
+    assert "Diverging" in _CMAP_GROUPS
+    assert "Qualitative" in _CMAP_GROUPS
+    assert "Miscellaneous" in _CMAP_GROUPS
+
+
+def test_cmap_groups_key_members():
+    assert "viridis" in _CMAP_GROUPS["Perceptually Uniform"]
+    assert "coolwarm" in _CMAP_GROUPS["Diverging"]
+    assert "tab10" in _CMAP_GROUPS["Qualitative"]
+
+
+# ---------------------------------------------------------------------------
+# DropdownDialog — layout and behaviour
+# ---------------------------------------------------------------------------
+
+def test_dropdown_dialog_no_fixed_size(qtbot):
+    """Dialog must not have a fixed size — both dimensions should be flexible."""
+    dialog = DropdownDialog(
+        "Test", OrderedDict(Val={"type": QDoubleSpinBox, "value": 1.0}),
+        func=lambda v: None,
+    )
+    qtbot.addWidget(dialog)
+    # setFixedSize pins min == max; the new layout must not do this
+    assert dialog.minimumWidth() != dialog.maximumWidth() or dialog.maximumWidth() == 16777215
+    assert dialog.minimumHeight() != dialog.maximumHeight() or dialog.maximumHeight() == 16777215
+
+
+def test_dropdown_dialog_get_selections_combobox(qtbot):
+    called = {}
+    dialog = DropdownDialog(
+        "T",
+        OrderedDict(Color={
+            "type": QComboBox,
+            "items": ["navy", "crimson"],
+            "icon_factory": _color_icon,
+            "icon_size": QSize(32, 16),
+            "clear_text": True,
+        }),
+        func=lambda v: called.update(value=v),
+    )
+    qtbot.addWidget(dialog)
+    dialog.widgets[0].setCurrentIndex(1)
+    assert dialog.get_selections() == ["crimson"]
+
+
+def test_dropdown_dialog_get_selections_spinbox(qtbot):
+    out = {}
+    dialog = DropdownDialog(
+        "T",
+        OrderedDict(Val={"type": QDoubleSpinBox, "value": 0.0}),
+        func=lambda v: out.update(v=v),
+    )
+    qtbot.addWidget(dialog)
+    dialog.widgets[0].setValue(7.5)
+    assert dialog.get_selections() == [7.5]
+
+
+def test_dropdown_dialog_ok_calls_func(qtbot):
+    results = []
+    dialog = DropdownDialog(
+        "T",
+        OrderedDict(Val={"type": QDoubleSpinBox, "value": 2.0}),
+        func=lambda v: results.append(v),
+        ok_cancel_button=True,
+    )
+    qtbot.addWidget(dialog)
+    dialog.widgets[0].setValue(9.9)
+    dialog.accept()
+    assert len(results) == 1
+    assert abs(results[0] - 9.9) < 1e-6
+
+
+def test_dropdown_dialog_cancel_does_not_call_func(qtbot):
+    results = []
+    dialog = DropdownDialog(
+        "T",
+        OrderedDict(Val={"type": QDoubleSpinBox, "value": 0.0}),
+        func=lambda v: results.append(v),
+        ok_cancel_button=True,
+    )
+    qtbot.addWidget(dialog)
+    dialog.reject()
+    assert results == []
+
+
+def test_dropdown_dialog_immediate_update_on_change(qtbot):
+    """Without ok_cancel_button, item_changed fires on activated — including same-index re-selection."""
+    results = []
+    dialog = DropdownDialog(
+        "T",
+        OrderedDict(Color={
+            "type": QComboBox,
+            "items": ["a", "b"],
+        }),
+        func=lambda v: results.append(v),
+        ok_cancel_button=False,
+    )
+    qtbot.addWidget(dialog)
+    # activated fires even when the user picks the already-selected item
+    dialog.widgets[0].activated.emit(0)
+    assert len(results) == 1
+
+
+def test_dropdown_dialog_multiple_widgets(qtbot):
+    """Multiple widgets are laid out and get_selections returns all values."""
+    out = {}
+    dialog = DropdownDialog(
+        "T",
+        OrderedDict(
+            A={"type": QComboBox, "items": ["x", "y"], "current_index": 1},
+            B={"type": QDoubleSpinBox, "value": 3.0},
+        ),
+        func=lambda a, b: out.update(a=a, b=b),
+        ok_cancel_button=True,
+    )
+    qtbot.addWidget(dialog)
+    assert dialog.get_selections() == ["y", 3.0]
+    dialog.accept()
+    assert out == {"a": "y", "b": 3.0}

--- a/tests/test_widget_menu.py
+++ b/tests/test_widget_menu.py
@@ -9,7 +9,6 @@ from PySide6.QtWidgets import QComboBox, QDoubleSpinBox
 from pynaviz.qt.drop_down_dict_builder import _CMAP_GROUPS, _cmap_icon, _color_icon
 from pynaviz.qt.widget_menu import DropdownDialog, widget_factory
 
-
 # ---------------------------------------------------------------------------
 # widget_factory — flat combobox
 # ---------------------------------------------------------------------------
@@ -171,7 +170,6 @@ def test_color_icon_returns_pixmap(qtbot):
 
 def test_color_icon_fill(qtbot):
     """The pixmap is filled with the requested colour (sample centre pixel)."""
-    from PySide6.QtGui import QColor
     px = _color_icon("red")
     img = px.toImage()
     center = img.pixelColor(16, 8)

--- a/tests/test_widget_menu.py
+++ b/tests/test_widget_menu.py
@@ -217,21 +217,6 @@ def test_cmap_groups_no_duplicates():
     all_names = [n for names in _CMAP_GROUPS.values() for n in names]
     assert len(all_names) == len(set(all_names)), "Duplicate cmap names in _CMAP_GROUPS"
 
-
-def test_cmap_groups_known_categories():
-    assert "Perceptually Uniform" in _CMAP_GROUPS
-    assert "Sequential" in _CMAP_GROUPS
-    assert "Diverging" in _CMAP_GROUPS
-    assert "Qualitative" in _CMAP_GROUPS
-    assert "Miscellaneous" in _CMAP_GROUPS
-
-
-def test_cmap_groups_key_members():
-    assert "viridis" in _CMAP_GROUPS["Perceptually Uniform"]
-    assert "coolwarm" in _CMAP_GROUPS["Diverging"]
-    assert "tab10" in _CMAP_GROUPS["Qualitative"]
-
-
 # ---------------------------------------------------------------------------
 # DropdownDialog — layout and behaviour
 # ---------------------------------------------------------------------------
@@ -290,7 +275,7 @@ def test_dropdown_dialog_ok_calls_func(qtbot):
     dialog.widgets[0].setValue(9.9)
     dialog.accept()
     assert len(results) == 1
-    assert abs(results[0] - 9.9) < 1e-6
+    assert results[0] == 9.9
 
 
 def test_dropdown_dialog_cancel_does_not_call_func(qtbot):


### PR DESCRIPTION
# Dialog layout fixes and visual improvements

## Problem

Action dialogs (`DropdownDialog`) were cropping their content due to hardcoded fixed dimensions
(`setFixedWidth(200 * num_cols)`, `setFixedHeight(150 * num_rows)`) computed before the layout
was fully built, making `adjustSize()` a no-op. The nested layout (VBox → HBox + two expanding
spacers inside a scroll area) was also fighting the widget sizes.

## Changes

### Layout fix (`widget_menu.py`)
- Removed hardcoded `setFixedWidth`/`setFixedHeight`; `adjustSize()` now works correctly
- Simplified the scroll area layout: `QGridLayout` parented directly to `scroll_content`,
  no intermediate spacers
- Added proper margins (12px outer, 8px inner) and spacing
- Removed `QScrollArea` frame (was producing a double border)
- Input widgets now use `Expanding` horizontal size policy so they fill available width

### Color and colormap icons (`widget_menu.py`, `drop_down_dict_builder.py`)
- Color comboboxes (in "Plot x vs y") show a solid-color swatch instead of the color name;
  name appears as a tooltip on hover
- Colormap comboboxes (in "Color by") show a gradient preview instead of the cmap name;
  name appears as a tooltip on hover
- Cmaps are grouped by category (Perceptually Uniform, Sequential, Diverging, Cyclic,
  Qualitative, Miscellaneous) with bold section headers and separators; order within each
  group follows the matplotlib docs for perceptual consistency
- Icon rendering is driven by a generic `icon_factory` callable in the widget params dict —
  no type-specific branches in `widget_factory`
