### PR TITLE
Bug fixes: stale metadata on layout restore + single-item combobox action

### DIFF
--- a/src/pynaviz/plot_manager.py
+++ b/src/pynaviz/plot_manager.py
@@ -316,7 +316,14 @@ class _PlotManager:
         self.reset(base_plot, index=index)
         for action, kwargs in state['_actions'].items():
             attr = getattr(base_plot, action, None)
-            if kwargs is not None and attr is not None:
-                attr(**kwargs)
+            if kwargs is None or attr is None:
+                continue
+            metadata_name = kwargs.get("metadata_name")
+            if metadata_name is not None:
+                metadata = getattr(base_plot.data, "metadata", None)
+                if metadata is not None and metadata_name not in metadata.columns:
+                    print(f"Skipping '{action}': metadata field '{metadata_name}' not found in current data.")
+                    continue
+            attr(**kwargs)
         return self
 

--- a/src/pynaviz/qt/widget_menu.py
+++ b/src/pynaviz/qt/widget_menu.py
@@ -182,8 +182,8 @@ class DropdownDialog(QDialog):
 
         for i, (label, params) in enumerate(widgets.items()):
             widget = widget_factory(params)
-            if hasattr(widget, "currentIndexChanged"):
-                widget.currentIndexChanged.connect(self.item_changed)
+            if hasattr(widget, "activated"):
+                widget.activated.connect(self.item_changed)
             if hasattr(widget, "valueChanged"):
                 widget.valueChanged.connect(self.item_changed)
 

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -487,6 +487,43 @@ def test_save_load_layout_active_controller(varname, from_key, to_key, main_wind
     _assert_round_trip(main_window, variables, tmp_path, qtbot)
 
 
+@pytest.mark.parametrize("action,kwargs", [
+    ("group_by", {"metadata_name": "channel"}),
+    ("sort_by", {"metadata_name": "channel"}),
+    ("color_by", {"metadata_name": "channel", "cmap_name": "viridis", "vmin": 0, "vmax": 4}),
+])
+def test_restore_layout_skips_stale_metadata_action(action, kwargs, main_window__dock, tmp_path, qtbot):
+    """Layout restore silently skips actions referencing metadata fields that no longer exist."""
+    main_window, variables = main_window__dock
+    tsdframe = variables["tsdframe"]
+
+    dock_widget = main_window.add_dock_widget(tsdframe, ["tsdframe"])
+    widget = dock_widget.widget()
+    apply_action(widget=widget, action_type=action, action_kwargs=kwargs, qtbot=qtbot)
+    assert widget.plot._manager._actions[action] is not None
+
+    layout_path = tmp_path / "layout.json"
+    main_window._save_layout(layout_path)
+    main_window.close()
+
+    # drop_info modifies in place — tsdframe (and variables["tsdframe"]) no longer has "channel"
+    tsdframe.drop_info("channel")
+
+    main_window_new = viz.qt.mainwindow.MainWindow(
+        variables=variables, layout_path=layout_path
+    )
+    qtbot.addWidget(main_window_new)
+
+    tsdframe_dock = next(
+        d for d in main_window_new.findChildren(QDockWidget)
+        if d.objectName() != "VariablesDock"
+    )
+    # Stale action must have been skipped — manager entry stays None
+    assert tsdframe_dock.widget().plot._manager._actions[action] is None
+
+    main_window_new.close()
+
+
 def test_save_load_layout_view_and_time(main_window__dock, tmp_path, qtbot):
     """Camera view (xmin, xmax, ymin, ymax) and current time persist through save/load."""
     main_window, variables = main_window__dock


### PR DESCRIPTION

## Bugs fixed

### 1. Layout restore replays actions for metadata fields that no longer exist

When a layout was saved with a `group_by`, `sort_by`, or `color_by` action referencing a
metadata field (e.g. `"channel"`), and the field was subsequently dropped from the data,
restoring the layout would silently fail or replay the action against missing data.

**Fix (`plot_manager.py`):** `_PlotManager.from_state` now validates each saved action's
`metadata_name` against the current data's metadata columns before replaying it. Actions
referencing missing fields are skipped with a log message.

### 2. Single-item combobox never fires in non-modal dialogs

In `DropdownDialog`, widget changes were connected to `currentIndexChanged`. When a
combobox has only one option (e.g. a metadata column with a single entry), the index never
changes so the action was never applied.

**Fix (`widget_menu.py`):** Changed the signal to `activated`, which fires whenever the
user selects an item from the popup regardless of whether the index changed.

## Test

`test_restore_layout_skips_stale_metadata_action` — parametrised over `group_by`,
`sort_by`, and `color_by`: applies an action using a metadata field, saves the layout,
drops the field with `drop_info`, restores the layout, and asserts the stale action entry
in the manager is `None`.