### PR TITLE
Fast pts extract and buffer

### DIFF
--- a/src/pynaviz/audiovideo/base_audiovideo.py
+++ b/src/pynaviz/audiovideo/base_audiovideo.py
@@ -51,8 +51,15 @@ class BaseAudioVideo:
             return True
 
         with self._lock:
-            # return if empty list or empty array or not enough frmae
-            if len(self._keyframe_pts) == 0 or self._keyframe_pts[-1] < target_frame_pts:
+            if len(self._keyframe_pts) == 0:
+                return True
+            # While the keyframe thread is still running we may not yet know
+            # about a keyframe that sits between current position and target.
+            # Seek conservatively so we don't miss it.
+            # Once the thread is done the list is complete: no keyframe beyond
+            # the last known one exists, so the absence of one is not a reason
+            # to seek — we can stream forward safely.
+            if not self._pts_keyframe_ready.is_set() and self._keyframe_pts[-1] < target_frame_pts:
                 return True
 
         # roll back the stream if audiovideo is scrolled backwards
@@ -63,10 +70,8 @@ class BaseAudioVideo:
         idx = np.searchsorted(self._keyframe_pts, target_frame_pts, side="right")
         closest_keyframe_pts = self._keyframe_pts[max(0, idx - 1)]
 
-        # if target_frame_pts is larger than current (and if code
-        # arrives here, it is, see second return statement),
-        # then seek forward if there is a future keyframe closest
-        # to the target.
+        # seek forward only if there is a keyframe between current position
+        # and the target (i.e. a closer starting point exists).
         return closest_keyframe_pts > current_frame_pts
 
 

--- a/src/pynaviz/audiovideo/video_handling.py
+++ b/src/pynaviz/audiovideo/video_handling.py
@@ -157,6 +157,9 @@ class VideoHandler(BaseAudioVideo):
         self.key_mask = None
 
         self._i = 0  # number of committed (valid) PTS entries
+        # None means the total frame count is not yet known (e.g. vp9/webm);
+        # set to the final count by _build_index before signalling _index_ready.
+        self._n_frames: int | None = self.stream.frames if self.stream.frames > 0 else None
         self._index_thread = threading.Thread(target=self._build_index, daemon=True)
 
         self._index_ready = threading.Event()
@@ -329,6 +332,18 @@ class VideoHandler(BaseAudioVideo):
         except Exception as e:
             print("Index thread error:", e)
         finally:
+            self._n_frames = self._i
+            if self._time_provided and len(self.time) != self._i:
+                warnings.warn(
+                    f"The provided time array has length {len(self.time)}, but the video has {self._i} frames. "
+                    "Overriding time with `np.linspace(time[0], time[-1], n_frames)`.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                self.time = np.linspace(self.time[0], self.time[-1], self._i)
+            elif not self._time_provided and len(self.time) != self._i:
+                frame_duration = 1 / float(self.stream.average_rate)
+                self.time = np.linspace(0, frame_duration * self._i - frame_duration, self._i)
             self._index_ready.set()
 
     def _get_frame_idx(self, pts: int) -> int:
@@ -417,7 +432,7 @@ class VideoHandler(BaseAudioVideo):
         idx = self.last_loaded_idx
         if idx is None:
             # fallback to safe keyframe
-            self._pts_keyframe_ready.wait(2.0)
+            self._wait_for_key_pts()
             if len(self._keyframe_pts) > 0:
                 idx = self._get_frame_idx(self._keyframe_pts[0])[0] + 1
             else:
@@ -595,25 +610,9 @@ class VideoHandler(BaseAudioVideo):
           may grow while the background indexer discovers frames. A warning is
           emitted until indexing is complete.
         """
-        if (
-            self._time_provided
-        ):  # TODO maybe check what is the actual number of frames decoded and throw a warning
-            return len(self.time), self.stream.width, self.stream.height
-        has_frames = hasattr(self.stream, "frames") and self.stream.frames > 0
-        is_done_unpacking = self._index_ready.is_set()
-        if not has_frames and not is_done_unpacking:
-            warnings.warn(
-                message="Video ``shape``, which corresponds to the number of frames, is being "
-                "calculated runtime and will be updated.",
-                stacklevel=2,
-            )
-        with self._lock:
-            current_len = self._i
-        return (
-            (len(self.time), self.stream.width, self.stream.height)
-            if has_frames
-            else (current_len, self.stream.width, self.stream.height)
-        )
+        if self._n_frames is None:
+            self._wait_for_all_pts()
+        return self._n_frames, self.stream.width, self.stream.height
 
     @property
     def index(self) -> NDArray:
@@ -624,18 +623,7 @@ class VideoHandler(BaseAudioVideo):
         Otherwise, a uniformly spaced array derived from the stream rate is used
         and may be updated as indexing progresses.
         """
-        if self._time_provided:
-            return self.time
-        else:
-            has_frames = hasattr(self.stream, "frames") and self.stream.frames > 0
-            is_done_unpacking = self._index_ready.is_set()
-            if not has_frames and not is_done_unpacking:
-                warnings.warn(
-                    message="Video ``shape``, which corresponds to the number of frames, is being "
-                    "calculated runtime and will be updated.",
-                    stacklevel=2,
-                )
-            return self.time
+        return self.time
 
     @property
     def t(self) -> NDArray:
@@ -648,14 +636,18 @@ class VideoHandler(BaseAudioVideo):
         """
         return self.time
 
-    def _wait_for_index(self, timeout=2.0):
-        """Wait up to timeout.
-
-        For debugging purposes, or testing, make sure that the
-        threads are completed.
-        """
+    def _wait_for_all_pts(self, timeout=None):
+        """Wait until the PTS index thread has finished."""
         self._index_ready.wait(timeout)
+
+    def _wait_for_key_pts(self, timeout=None):
+        """Wait until the keyframe PTS thread has finished."""
         self._pts_keyframe_ready.wait(timeout)
+
+    def _wait_for_index(self, timeout=None):
+        """Wait until both the PTS index and keyframe threads have finished."""
+        self._wait_for_all_pts(timeout)
+        self._wait_for_key_pts(timeout)
 
     def get_slice(self, start: float, end: float = None):
         # TODO check start and end are sorted
@@ -678,14 +670,15 @@ class VideoHandler(BaseAudioVideo):
         idx_end: int,
         step: int = 1,
     ) -> Tuple[int, List[av.VideoFrame] | NDArray, av.VideoFrame]:
-        effective_end = min(idx_end, self.shape[0])
+        n_frames = self._n_frames if self._n_frames is not None else self.shape[0]
+        effective_end = min(idx_end, n_frames)
         indices = np.arange(idx_start, effective_end, step)
         num_frames = len(indices)
         time_threshold_all = self.round_fn(indices)
 
         if self.return_frame_array:
             frames = np.empty(
-                (num_frames, self.shape[2], self.shape[1], 3),
+                (num_frames, self.stream.height, self.stream.width, 3),
                 dtype=np.float32,
             )
         else:
@@ -776,21 +769,24 @@ class VideoHandler(BaseAudioVideo):
               otherwise a ``list[av.VideoFrame]``.
         """
         if isinstance(idx, slice):
+            # Resolve frame count once — fast path if already known, otherwise waits.
+            n_frames = self._n_frames if self._n_frames is not None else self.shape[0]
+
             # Fill in missing slice components
             start = idx.start or 0
-            if start >= self.shape[0]:
+            if start >= n_frames:
                 if self.return_frame_array:
-                    return np.empty((0, self.shape[2], self.shape[1], 3))
+                    return np.empty((0, self.stream.height, self.stream.width, 3))
                 else:
                     return []
-            stop = idx.stop if idx.stop is not None else self.shape[0]
+            stop = idx.stop if idx.stop is not None else n_frames
             step = idx.step if idx.step is not None else 1
 
             # convert negative vals
-            start = start if start >= 0 else start + self.shape[0]
-            start = max(0, min(start, self.shape[0]))
-            stop = stop + self.shape[0] if stop < 0 else stop
-            stop = max(0, min(stop, self.shape[0]))
+            start = start if start >= 0 else start + n_frames
+            start = max(0, min(start, n_frames))
+            stop = stop + n_frames if stop < 0 else stop
+            stop = max(0, min(stop, n_frames))
 
             # revert slice if negative step
             revert = step < 0
@@ -820,7 +816,8 @@ class VideoHandler(BaseAudioVideo):
         with self._set_get_from_index(True):
             # TODO Check borders
             idx_start = idx if not hasattr(idx, "start") else idx.start
-            idx_start = idx_start if idx_start >= 0 else self.shape[0] + idx_start
+            n_frames = self._n_frames if self._n_frames is not None else self.shape[0]
+            idx_start = idx_start if idx_start >= 0 else n_frames + idx_start
             frame = self.get(idx_start)
             # handle slice requesting a single frame:
             # for arrays add 1 dimension (1, pixel, pixel)

--- a/src/pynaviz/audiovideo/video_handling.py
+++ b/src/pynaviz/audiovideo/video_handling.py
@@ -4,6 +4,7 @@ import pathlib
 import threading
 import time
 import warnings
+from collections import deque
 from contextlib import contextmanager
 from typing import List, Optional, Tuple
 
@@ -14,6 +15,53 @@ import numpy as np
 from numpy.typing import NDArray
 
 from .base_audiovideo import BaseAudioVideo
+
+# Number of packets to buffer before flushing to the index for codecs without
+# B-frames (where packet PTS are already in display order).
+_INDEX_FLUSH_EVERY = 64
+
+
+def _needs_flush(count_keyframes: int, temp: list, has_b_frames: bool, n_b_frames: int = 1) -> bool:
+    """True when the buffered GOP / batch is ready to commit to the index."""
+    if has_b_frames:
+        return (count_keyframes == n_b_frames) and bool(temp)
+    return len(temp) >= _INDEX_FLUSH_EVERY
+
+
+class FrameBuffer:
+    """Fixed-size FIFO cache mapping frame index → raw av.VideoFrame.
+
+    Frames are stored in their native pixel format; conversion happens on
+    retrieval, matching the existing behaviour of VideoHandler.
+
+    Parameters
+    ----------
+    maxsize :
+        Maximum number of frames to keep. When full the oldest-inserted
+        entry is evicted before adding a new one.
+    """
+
+    def __init__(self, maxsize: int = 30) -> None:
+        self._maxsize = maxsize
+        self._cache: dict[int, av.VideoFrame] = {}
+        self._order: deque[int] = deque()
+
+    def get(self, idx: int) -> av.VideoFrame | None:
+        """Return the cached frame for *idx*, or ``None`` on a miss."""
+        return self._cache.get(idx)
+
+    def put(self, idx: int, frame: av.VideoFrame) -> None:
+        """Insert *frame* under *idx*, evicting the oldest entry if full."""
+        if idx in self._cache:
+            return
+        if len(self._cache) == self._maxsize:
+            evict = self._order.popleft()
+            del self._cache[evict]
+        self._cache[idx] = frame
+        self._order.append(idx)
+
+    def __contains__(self, idx: int) -> bool:
+        return idx in self._cache
 
 
 class VideoHandler(BaseAudioVideo):
@@ -64,12 +112,17 @@ class VideoHandler(BaseAudioVideo):
         stream_index: int = 0,
         time: Optional[NDArray] = None,
         return_frame_array: bool = True,
+        buffer_size: int = 30,
     ) -> None:
         super().__init__(video_path)
         self.stream = self.container.streams.video[stream_index]
         self.stream_index = stream_index
         self.return_frame_array = return_frame_array
-
+        self._buffer = FrameBuffer(maxsize=buffer_size)
+        # pts of the last frame *actually decoded* from the stream — used for
+        # seek decisions.  current_frame can be updated by buffer / cache hits
+        # without advancing the stream, so it must not be used for this purpose.
+        self._stream_pts: int | None = None
 
         # default to linspace
         # TODO : what if number of frames is 0.
@@ -99,15 +152,12 @@ class VideoHandler(BaseAudioVideo):
             self.round_fn = lambda x: x
 
         # These will be initialized in the thread once n_frames is known
-        self.all_pts = None
+        self.all_pts: np.ndarray | list = []
         self.all_times = None
         self.key_mask = None
 
-        self._i = 0  # write position
-        if self.stream.frames and self.stream.frames > 0:
-            self._index_thread = threading.Thread(target=self._build_index_fixed_size, daemon=True)
-        else:
-            self._index_thread = threading.Thread(target=self._build_index_dynamic, daemon=True)
+        self._i = 0  # number of committed (valid) PTS entries
+        self._index_thread = threading.Thread(target=self._build_index, daemon=True)
 
         self._index_ready = threading.Event()
         self._index_thread.start()
@@ -226,54 +276,56 @@ class VideoHandler(BaseAudioVideo):
         finally:
             self._pts_keyframe_ready.set()
 
-    def _build_index_fixed_size(self):
+    def _build_index(self):
         try:
             with av.open(self.file_path) as container:
                 stream = container.streams.video[self.stream_index]
                 n_frames = stream.frames
+                ctx = stream.codec_context
+                has_b_frames = bool(ctx.has_b_frames)
+                # guard against max_b_frames set to None for non-b-frame codecs
+                max_b_frames = max(getattr(ctx, "max_b_frames", 1) or 1, 1)
+                process = sorted if has_b_frames else lambda x: x
+                temp = []
+                # setup config for fixed-size and variable size index.
+                if n_frames > 0:
+                    # preallocate indices
+                    with self._lock:
+                        self.all_pts = np.empty(n_frames, dtype=np.int64)
 
-                if not n_frames or n_frames <= 0:
-                    raise ValueError("Cannot determine total number of frames in stream.")
-
-                self.all_pts = np.empty(n_frames, dtype=np.int64)
-                self._i = 0  # Number of valid entries
-
-                for packet in container.demux(stream):
-                    if not self._running:
-                        return
-                    for frame in packet.decode():
-                        if self._i >= n_frames:
-                            break
+                    def update(extracted_pts):
+                        chunk = process(extracted_pts)
                         with self._lock:
-                            self.all_pts[self._i] = frame.pts
-                            self._i += 1
-        except Exception as e:
-            print("Index thread error:", e)
-        finally:
-            self._index_ready.set()
+                            self.all_pts[self._i: self._i + len(chunk)] = chunk
+                            self._i += len(chunk)
+                        extracted_pts.clear()
+                else:
+                    def update(extracted_pts):
+                        chunk = process(extracted_pts)
+                        with self._lock:
+                            self.all_pts.extend(chunk)
+                            self._i = len(self.all_pts)
+                        extracted_pts.clear()
 
-    def _build_index_dynamic(self):
-        try:
-            with av.open(self.file_path) as container:
-                if not self._running:
-                    return
-                stream = container.streams.video[self.stream_index]
-                pts_list = []
-
-                current_index = 0
-                flush_every = 10
-
+                # extraction loop: demux only — no decode — sort per GOP if needed.
+                count_key_frames = 0
                 for packet in container.demux(stream):
                     if not self._running:
                         return
-                    for frame in packet.decode():
-                        if frame.pts is not None:
-                            pts_list.append(frame.pts)
-                            if current_index % flush_every == 1:
-                                with self._lock:
-                                    self.all_pts = pts_list
-                                    self._i = current_index
-                            current_index += 1
+                    if packet.pts is None or packet.pts < 0:
+                        continue
+
+                    count_key_frames += packet.is_keyframe
+                    if _needs_flush(count_key_frames, temp, has_b_frames, max_b_frames):
+                        update(temp)
+                        count_key_frames = 0
+                    temp.append(packet.pts)
+
+                if temp:
+                    update(temp)
+                with self._lock:
+                    self.all_pts = np.asarray(self.all_pts[: self._i], dtype=np.int64)
+
         except Exception as e:
             print("Index thread error:", e)
         finally:
@@ -299,10 +351,10 @@ class VideoHandler(BaseAudioVideo):
         # Wait until enough index is available
         # Estimate pts from index (using filled index if available)
         with self._lock:
-            done = self.all_pts[min(self._i, len(self.all_pts) - 1)] > pts
+            done = self._i > 0 and self.all_pts[self._i - 1] > pts
         if done:
             # the pts for this timestamp has been filled
-            idx = np.searchsorted(self.all_pts, pts, side="right")
+            idx = np.searchsorted(self.all_pts[: self._i], pts, side="left")
             use_time = False
         else:
             # keep going until at least two frames have been decoded by the thread
@@ -367,7 +419,7 @@ class VideoHandler(BaseAudioVideo):
             # fallback to safe keyframe
             self._pts_keyframe_ready.wait(2.0)
             if len(self._keyframe_pts) > 0:
-                idx = self._get_frame_idx(self._keyframe_pts[0])[0]
+                idx = self._get_frame_idx(self._keyframe_pts[0])[0] + 1
             else:
                 idx = 0  # safe fallback
 
@@ -406,7 +458,7 @@ class VideoHandler(BaseAudioVideo):
         self.current_frame = frame
 
         # Get the index of the key frame
-        self.last_loaded_idx = self._get_frame_idx(frame.pts)[0] - 1
+        self.last_loaded_idx = self._get_frame_idx(frame.pts)[0]
 
         # Return both
         return (
@@ -451,11 +503,19 @@ class VideoHandler(BaseAudioVideo):
                 else self.current_frame
             )
 
+        cached = self._buffer.get(idx)
+        if cached is not None:
+            self.current_frame = cached
+            self.last_loaded_idx = idx
+            return (
+                cached.to_ndarray(format="rgb24")[::-1] / 255.0
+                if self.return_frame_array
+                else cached
+            )
+
         target_pts, use_time = self._get_target_frame_pts(idx)
 
-        if not hasattr(self.current_frame, "pts") or self._need_seek_call(
-            self.current_frame.pts, target_pts
-        ):
+        if self._stream_pts is None or self._need_seek_call(self._stream_pts, target_pts):
             self.container.seek(
                 int(target_pts), backward=True, any_frame=False, stream=self.stream
             )
@@ -466,6 +526,8 @@ class VideoHandler(BaseAudioVideo):
         if preceding_frame is not None:
             self.last_loaded_idx = idx
             self.current_frame = preceding_frame
+            self._stream_pts = preceding_frame.pts
+            self._buffer.put(idx, preceding_frame)
 
         return (
             self.current_frame.to_ndarray(format="rgb24")[::-1] / 255.0
@@ -612,7 +674,6 @@ class VideoHandler(BaseAudioVideo):
 
     def _decode_multiple(
         self,
-        target_pts,
         idx_start: int,
         idx_end: int,
         step: int = 1,
@@ -637,81 +698,59 @@ class VideoHandler(BaseAudioVideo):
             self.get(0)
 
         preceding_frame = self.current_frame
-        last_frame = self.current_frame  # safe fallback if no packet yields frames
-        go_to_next_packet = False
+        last_frame = self.current_frame
+        decoder = None  # frame-level iterator; reset after every seek
 
         while collected < num_frames:
-            if not go_to_next_packet:
-                target_pts, use_time = self._get_target_frame_pts(indices[collected])
+            # check buffer first
+            cached = self._buffer.get(indices[collected])
+            if cached is not None:
+                self.current_frame = cached
+                self.last_loaded_idx = indices[collected]
+                self._append_frame(frames, collected, cached)
+                preceding_frame = cached
+                last_frame = cached
+                collected += 1
+                continue
 
-            # First frame shortcut
-            if collected == 0 and hasattr(self.current_frame, "pts"):
-                if self.current_frame.pts == target_pts:
-                    self._append_frame(frames, collected, self.current_frame)
-                    collected = 1
-                    continue
-                elif self.current_frame.pts > target_pts:
-                    self.current_frame = None
-                    self.container.seek(
-                        int(target_pts),
-                        backward=True,
-                        any_frame=False,
-                        stream=self.stream,
-                    )
-                    go_to_next_packet = True
+            target_pts, use_time = self._get_target_frame_pts(indices[collected])
 
-            if not go_to_next_packet and self._need_seek_call(preceding_frame.pts, target_pts):
+            # Open a decoder (or re-open after a seek) when needed.
+            if decoder is None or (
+                self._need_seek_call(self._stream_pts, target_pts)
+            ):
                 self.container.seek(
-                    int(target_pts),
-                    backward=True,
-                    any_frame=False,
-                    stream=self.stream,
+                    int(target_pts), backward=True, any_frame=False, stream=self.stream
                 )
+                decoder = self.container.decode(self.stream)
 
-            packet = next(self.container.demux(self.stream))
-
+            # Advance one frame. container.decode handles B-frame buffering
+            # internally, so zero-frame packets are transparent to us.
             try:
-                decoded = packet.decode()
-                while len(decoded) == 0:
-                    decoded = packet.decode()
-            except av.error.EOFError:
-                # end of the video, rewind
+                frame = next(f for f in decoder if f.pts is not None)
+                self._buffer.put(self._get_frame_idx(frame.pts)[0], frame)
+                self._stream_pts = frame.pts
+            except StopIteration:
                 break
 
-            for frame in decoded:
-                if frame.pts is None:
-                    continue
+            time_threshold = time_threshold_all[collected]
+            found_next = (
+                (frame.pts > target_pts) if not use_time else (frame.time > time_threshold)
+            )
+            found_current = (
+                (frame.pts == target_pts) if not use_time else (frame.time == time_threshold)
+            )
 
-                time_threshold = time_threshold_all[collected]
-                found_next = (
-                    (frame.pts > target_pts) if not use_time else (frame.time > time_threshold)
-                )
-                found_current = (
-                    (frame.pts == target_pts) if not use_time else (frame.time == time_threshold)
-                )
+            if found_next:
+                frame = preceding_frame or frame
+                self._append_frame(frames, collected, frame)
+                collected += 1
+            elif found_current:
+                self._append_frame(frames, collected, frame)
+                collected += 1
 
-                if found_next:
-                    self._append_frame(frames, collected, preceding_frame)
-                    collected += 1
-                    go_to_next_packet = False
-                    if collected < num_frames:
-                        target_pts, use_time = self._get_target_frame_pts(indices[collected])
-
-                elif found_current:
-                    self._append_frame(frames, collected, frame)
-                    collected += 1
-                    go_to_next_packet = False
-                    if collected < num_frames:
-                        target_pts, use_time = self._get_target_frame_pts(indices[collected])
-
-                else:
-                    go_to_next_packet = True
-
-                if collected >= num_frames:
-                    break
-
-                last_frame = frame
-                preceding_frame = frame
+            last_frame = frame
+            preceding_frame = frame
 
         return indices[-1], frames, last_frame
 
@@ -760,20 +799,21 @@ class VideoHandler(BaseAudioVideo):
             if (stop - start) // step > 1:
                 target_pts, use_time = self._get_target_frame_pts(start)
 
-                if not hasattr(self.current_frame, "pts") or self._need_seek_call(
-                    self.current_frame.pts, target_pts
+                if self._stream_pts is None or self._need_seek_call(
+                    self._stream_pts, target_pts
                 ):
                     self.container.seek(
                         int(target_pts), backward=True, any_frame=False, stream=self.stream
                     )
 
                 frame_idx, frames, last_frame = self._decode_multiple(
-                    target_pts, start, stop, step=step
+                    start, stop, step=step
                 )
                 # update current decoded frame
                 if len(frames):
                     self.last_loaded_idx = frame_idx
                     self.current_frame = last_frame
+                    self._stream_pts = last_frame.pts
                 return frames if not revert else frames[::-1]
 
         # Default case: single index

--- a/src/pynaviz/audiovideo/video_plot.py
+++ b/src/pynaviz/audiovideo/video_plot.py
@@ -299,6 +299,7 @@ class PlotVideo(PlotBaseVideoTensor):
         self,
         video: str | pathlib.Path | VideoHandler,
         t: Optional[NDArray] = None,
+        buffer_size_sec: float = 1.,
         stream_index: int = 0,
         index=None,
         start_worker: bool = True,
@@ -313,6 +314,11 @@ class PlotVideo(PlotBaseVideoTensor):
             Path to the video file to be visualized or a VideoHandler object.
         t : NDArray, optional
             Time vector to use for syncing frames.
+        buffer_size_sec: float
+            Duration of the recently-decoded frame cache in seconds (default 1 s).
+            Frames within this window are returned instantly on re-access without
+            any seek or decode. Larger values improve responsiveness during scrubbing
+            at the cost of additional memory.
         stream_index : int, default=0
             Index of the stream to read in the video file.
         index : int, optional
@@ -325,7 +331,10 @@ class PlotVideo(PlotBaseVideoTensor):
         """
         self._closed = False
         if isinstance(video, (str, pathlib.Path)):
-            data = VideoHandler(video, time=t, stream_index=stream_index)
+            with av.open(video) as container:
+                average_rate = container.streams.video[stream_index].average_rate
+                buffer_size = max(int(buffer_size_sec * average_rate), 1)
+            data = VideoHandler(video, time=t, stream_index=stream_index, buffer_size=buffer_size)
         else:
             if not isinstance(video, VideoHandler):
                 raise ValueError("video must be a file path or a VideoHandler instance.")

--- a/tests/test_video_handler.py
+++ b/tests/test_video_handler.py
@@ -77,6 +77,17 @@ def test_video_handler_get_frame_snapshots(
 
 
 @pytest.mark.parametrize("video_info", ["mp4", "mkv", "avi"], indirect=True)
+def test_pts_ordering(video_info):
+    frame_pts, _, video = video_info
+    with video_handling.VideoHandler(video, time=np.arange(100)) as handler:
+        handler._wait_for_index(15)
+        np.testing.assert_array_equal(handler.all_pts, np.sort(handler.all_pts))
+        np.testing.assert_array_equal(
+            handler.all_pts, np.asarray(frame_pts, dtype=handler.all_pts.dtype)
+        )
+
+
+@pytest.mark.parametrize("video_info", ["mp4", "mkv", "avi"], indirect=True)
 def test_getitem_single_index_return_frame(video_info):
     _, _, video_path = video_info
     with video_handling.VideoHandler(
@@ -240,3 +251,128 @@ def test_roundtrip_points(video_info):
     img2 = video_obj.renderer.snapshot()
     np.testing.assert_allclose(img, img2, atol=1)
     video_obj.close()
+
+
+# ---------------------------------------------------------------------------
+# Buffer integration tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("video_info", ["mp4", "mkv", "avi"], indirect=True)
+def test_get_populates_buffer(video_info):
+    """A frame decoded via get() should land in the buffer."""
+    _, _, video_path = video_info
+    with video_handling.VideoHandler(
+        video_path, time=np.arange(100), return_frame_array=False
+    ) as video:
+        video.get(5.0)
+        idx = video_handling.VideoHandler._ts_to_index(5.0, video.time)
+        assert idx in video._buffer
+
+
+@pytest.mark.parametrize("video_info", ["mp4", "mkv", "avi"], indirect=True)
+def test_get_hits_buffer_on_second_call(video_info):
+    """Second get() for the same timestamp must return the cached frame
+    without re-decoding — proved by closing the container between calls."""
+    _, _, video_path = video_info
+    with video_handling.VideoHandler(
+        video_path, time=np.arange(100), return_frame_array=False
+    ) as video:
+        first = video.get(5.0)
+
+        # Close the underlying container so any attempt to decode would raise.
+        video.container.close()
+        video.container = None
+
+        second = video.get(5.0)
+
+    assert first.pts == second.pts
+
+
+@pytest.mark.parametrize("video_info", ["mp4", "mkv", "avi"], indirect=True)
+def test_getitem_int_populates_buffer(video_info):
+    """video[idx] (integer index) routes through get(), so the frame should
+    end up in the buffer."""
+    _, _, video_path = video_info
+    with video_handling.VideoHandler(
+        video_path, time=np.arange(100), return_frame_array=False
+    ) as video:
+        idx = 10
+        video[idx]
+        assert idx in video._buffer
+
+
+@pytest.mark.parametrize("video_info", ["mp4", "mkv", "avi"], indirect=True)
+def test_getitem_int_hits_buffer_on_second_call(video_info):
+    """video[idx] called twice: second call must come from the buffer."""
+    _, _, video_path = video_info
+    with video_handling.VideoHandler(
+        video_path, time=np.arange(100), return_frame_array=False
+    ) as video:
+        idx = 10
+        first = video[idx]
+
+        video.container.close()
+        video.container = None
+
+        second = video[idx]
+
+    assert first.pts == second.pts
+
+
+@pytest.mark.parametrize("video_info", ["mp4", "mkv", "avi"], indirect=True)
+def test_buffer_fifo_eviction_in_handler(video_info):
+    """Accessing more than buffer_size distinct frames evicts the earliest one."""
+    _, _, video_path = video_info
+    buf_size = 5
+    with video_handling.VideoHandler(
+        video_path, time=np.arange(100), return_frame_array=False, buffer_size=buf_size
+    ) as video:
+        # warm up: access buf_size + 1 distinct frames (skip 0; __init__ decodes it)
+        for i in range(1, buf_size + 2):
+            video[i]
+
+        # frame at index 1 was inserted first and should have been evicted
+        assert 1 not in video._buffer
+        # the most recent buf_size frames must still be present
+        for i in range(2, buf_size + 2):
+            assert i in video._buffer
+
+
+@pytest.mark.parametrize("video_info", ["mp4", "mkv", "avi"], indirect=True)
+def test_getitem_decoupled_current_frame_and_pts_decoding_via_get(video_info):
+    _, _, video_path = video_info
+    with video_handling.VideoHandler(
+        video_path, time=np.arange(100), return_frame_array=False
+    ) as video_obj:
+        # populate the buffer with frames 10 and 11
+        _ = video_obj[10]
+        _ = video_obj[11]
+        # move current_frame back to 10 via buffer (should not advance the stream)
+        _ = video_obj[10]
+        # current_frame and stream pts must now differ
+        assert video_obj.current_frame.pts != video_obj._stream_pts
+        # decoding the next frame must still be correct
+        frame = video_obj[12]
+        with video_obj._set_get_from_index(True):
+            video_obj.get(12)
+            assert video_obj.current_frame.pts == frame.pts
+
+
+@pytest.mark.parametrize("video_info", ["mp4", "mkv", "avi"], indirect=True)
+def test_getitem_decoupled_current_frame_and_pts_decoding_via_decode_multiple(video_info):
+    _, _, video_path = video_info
+    with video_handling.VideoHandler(
+        video_path, time=np.arange(100), return_frame_array=False
+    ) as video_obj:
+        # populate the buffer via a slice
+        _ = video_obj[10:12]
+        # move current_frame back to 10 via buffer (should not advance the stream)
+        _ = video_obj[10]
+        # current_frame and stream pts must now differ
+        assert video_obj.current_frame.pts != video_obj._stream_pts
+        # decoding the next slice must still be correct
+        frames = video_obj[12:14]
+        with video_obj._set_get_from_index(True):
+            for i, frame in zip(range(12, 14), frames):
+                video_obj.get(i)
+                assert video_obj.current_frame.pts == frame.pts


### PR DESCRIPTION
## Summary

- **`FrameBuffer`**: a fixed-size FIFO cache (default 30 frames) mapping frame index → `av.VideoFrame`. On a cache hit in `get()` or `_decode_multiple()`, the frame is returned immediately without any seek or decode.

- **`buffer_size_sec`**:  new parameter of `VideoPlot`, set the buffer size in seconds. Default to 1 sec, the buffer size from time to number of frames is done internally.

- **`_stream_pts` pointer**: separates the actual stream head position from `current_frame`. `current_frame` can now be rewound to a buffered frame (backwards navigation) without confusing the seek-decision logic into thinking the stream head moved. The seek check in `get()`, `_decode_multiple()`, and the `__getitem__` slice path all switch from `current_frame.pts` to `_stream_pts`.

- **`_decode_multiple` rewrite**: replaces the old packet-at-a-time loop (with the first-frame shortcut, `go_to_next_packet` flag, and inner `for frame in decoded` iteration) with a cleaner `container.decode()` iterator. Each iteration checks the buffer first, then opens/reseeks a decoder only when `_need_seek_call` says so. Every decoded frame is also inserted into the buffer and advances `_stream_pts`. Removes the now-unused `target_pts` parameter.

- **`_get_frame_idx` fix**: `searchsorted(side="right")` was returning `i + 1` for exact matches, requiring every caller to subtract 1. Changed to `side="left"` (returns `i` directly); the one call site in `_get_key_frame` that genuinely needed `i + 1` gets an explicit `+ 1`.

- **`_need_seek_call` fix** (`base_audiovideo.py`): the old guard `keyframe_pts[-1] < target_frame_pts` caused spurious seeks when the keyframe-extraction thread was still running and the target was beyond the last known keyframe. Now the conservative seek only fires while the thread is still running; once it finishes, the absence of a further keyframe is treated as safe to stream forward.

- **`_build_index` unification**: merges `_build_index_fixed_size` and `_build_index_dynamic` into a single `_build_index` that uses packet demux (no decode) for speed, with GOP-aware sorting for B-frame codecs.

## Tests

- `test_pts_ordering`: verifies the unified index builder produces a sorted, correct PTS array.
- Buffer integration suite (6 tests × 3 codecs): `get()` and `__getitem__` populate the buffer; a second call returns from cache without touching the container; FIFO eviction works at configurable `buffer_size`.
- `test_getitem_decoupled_current_frame_and_pts_decoding_via_get/decode_multiple`: exercises the core correctness guarantee — after a backwards buffer hit splits `current_frame.pts` from `_stream_pts`, the next forward decode still lands on the right frame.