### PR TITLE
adding tree view of channels

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,29 +27,29 @@ tsdframe = nap.TsdFrame(
               "type": ["exc", "inh"]*5,
               "channel": np.arange(10)}
 )
-
-pose = nap.TsdFrame(
-    t=np.arange(10000)/30,
-    d=np.random.randn(10000, 10),
-    columns=["nose_x", "nose_y", "ear_r_x", "ear_r_y", "ear_l_x", "ear_l_y", "tailbase_x", "tailbase_y", "speed", "acceleration"]
-)
-
-tsdtensor = nap.TsdTensor(t=np.arange(10000)/30, d=np.random.randn(10000, 10, 10))
-
-
-iset = nap.IntervalSet(start=np.arange(0, 1000, 10), end=np.arange(5, 1005, 10))
-
-
-video_path = "docs/examples/m3v1mp4.mp4"
-v = viz.VideoHandler(video_path)
-
-
-df = pd.read_hdf("docs/examples/m3v1mp4DLC_Resnet50_openfieldOct30shuffle1_snapshot_best-70.h5")
-df.columns = [f"{bodypart}_{coord}" for _, bodypart, coord in df.columns]
-df = df[[c for c in df.columns if c.endswith(("_x", "_y"))]]
-y_col = [c for c in df.columns if c.endswith("_y")]
-df[y_col] = df[y_col]*-1 + 480 # Flipping y axis
-skeleton = nap.TsdFrame(t=df.index.values/30, d=df.values, columns=df.columns)
+#
+# pose = nap.TsdFrame(
+#     t=np.arange(10000)/30,
+#     d=np.random.randn(10000, 10),
+#     columns=["nose_x", "nose_y", "ear_r_x", "ear_r_y", "ear_l_x", "ear_l_y", "tailbase_x", "tailbase_y", "speed", "acceleration"]
+# )
+#
+# tsdtensor = nap.TsdTensor(t=np.arange(10000)/30, d=np.random.randn(10000, 10, 10))
+#
+#
+# iset = nap.IntervalSet(start=np.arange(0, 1000, 10), end=np.arange(5, 1005, 10))
+#
+#
+# video_path = "docs/examples/m3v1mp4.mp4"
+# v = viz.VideoHandler(video_path)
+#
+#
+# df = pd.read_hdf("docs/examples/m3v1mp4DLC_Resnet50_openfieldOct30shuffle1_snapshot_best-70.h5")
+# df.columns = [f"{bodypart}_{coord}" for _, bodypart, coord in df.columns]
+# df = df[[c for c in df.columns if c.endswith(("_x", "_y"))]]
+# y_col = [c for c in df.columns if c.endswith("_y")]
+# df[y_col] = df[y_col]*-1 + 480 # Flipping y axis
+# skeleton = nap.TsdFrame(t=df.index.values/30, d=df.values, columns=df.columns)
 
 scope(globals())
 

--- a/src/pynaviz/base_plot.py
+++ b/src/pynaviz/base_plot.py
@@ -909,10 +909,14 @@ class PlotTsdFrame(_BasePlot):
                 self._manager.scale = 1 / range_vals
 
             self._manager.offset = self._manager.offset + 1 - self._manager.offset.min()
+            self._manager.snapshot_base_offset()
             self._flush(*self.controller.get_xlim())
             self.controller.set_ylim(0, np.max(self._manager.offset) + 1)
 
         if action_name == "toggle_visibility":
+            if self._manager.is_sorted or self._manager.is_grouped:
+                y_max = self._manager.compact_visible_offsets()
+                self.controller.set_ylim(0, y_max + 1)
             self._mode.update_visibility()
 
         self.canvas.request_draw(self.animate)

--- a/src/pynaviz/display_modes.py
+++ b/src/pynaviz/display_modes.py
@@ -96,6 +96,8 @@ class LinesMode:
         """
         if self.stream._max_n == self.data.shape[0]:
             for i, c in enumerate(self.data.columns):
+                if not self.manager.data.loc[c]["visible"]:
+                    continue
                 sl = self._buffer_slices[c]
                 self.buffer[sl, 0] = self.data.t.astype("float32")
                 self.buffer[sl, 1] = self.data.d[:, i].astype("float32")
@@ -116,6 +118,8 @@ class LinesMode:
             data = np.array(self.data.values[slice_, :])
 
             for i, c in enumerate(self.data.columns):
+                if not self.manager.data.loc[c]["visible"]:
+                    continue
                 sl = self._buffer_slices[c]
                 sl = slice(sl.start + left_offset, sl.stop + right_offset)
                 self.buffer[sl, 0] = time
@@ -178,14 +182,11 @@ class LinesMode:
         self.manager.color_by(values, metadata_name, cmap_name=cmap_name, vmin=vmin, vmax=vmax)
 
     def update_visibility(self):
-        """Toggle channel visibility via the alpha channel of vertex colors."""
-        new_colors = self.graphic.geometry.colors.data.copy()
+        """Hide channels by NaN-ing their buffer positions; show them by re-flushing."""
         for c, sl in self._buffer_slices.items():
             if not self.manager.data.loc[c]["visible"]:
-                new_colors[sl, -1] = 0.0
-            else:
-                new_colors[sl, -1] = 1.0
-        self.graphic.geometry.colors.set_data(new_colors)
+                self.buffer[sl, 0:2] = np.nan
+        self.flush(self.stream._slice_)
 
     def get_state(self):
         """Return per-column scale factors and visibility as a JSON-serializable dict."""

--- a/src/pynaviz/plot_manager.py
+++ b/src/pynaviz/plot_manager.py
@@ -60,6 +60,7 @@ class _PlotManager:
             "color_by": None,
         }
         self.y_ticks = None
+        self._base_offset: np.ndarray | None = None
 
     @property
     def is_sorted(self) -> bool:
@@ -249,6 +250,57 @@ class _PlotManager:
         if was_grouped or was_sorted:
             self.scale = self.scale + (self.scale * factor)
 
+    def snapshot_base_offset(self) -> None:
+        """Snapshot the current offset array as the reference for compaction."""
+        self._base_offset = self.data["offset"].copy()
+
+    def compact_visible_offsets(self) -> float:
+        """Recompute display offsets for visible channels, closing gaps from hidden ones.
+
+        Returns
+        -------
+        float
+            New y-axis maximum (largest visible display offset), or 0.0 if
+            sort/group is not active or no base snapshot exists.
+        """
+        if not (self.is_sorted or self.is_grouped) or self._base_offset is None:
+            return 0.0
+
+        visible = self.visible
+        base = self._base_offset
+
+        visible_indices = np.where(visible)[0]
+        if len(visible_indices) == 0:
+            return 0.0
+
+        visible_base = base[visible_indices]
+        sort_order = np.argsort(visible_base, kind="stable")
+        sorted_visible_indices = visible_indices[sort_order]
+        sorted_visible_base = visible_base[sort_order]
+
+        # Start new display from 1.0 to match the +1 shift applied after sort/group.
+        new_display = base.copy()
+        current_display = 1.0
+        prev_base = sorted_visible_base[0]
+        new_display[sorted_visible_indices[0]] = current_display
+
+        for i in range(1, len(sorted_visible_indices)):
+            curr_base = sorted_visible_base[i]
+            gap = curr_base - prev_base
+
+            if gap == 0:
+                pass  # same display position
+            elif self.is_grouped and gap > 1:
+                current_display += 2  # group boundary
+            else:
+                current_display += 1  # consecutive within group or sort gap
+
+            new_display[sorted_visible_indices[i]] = current_display
+            prev_base = curr_base
+
+        self.data["offset"] = new_display.astype(np.float32)
+        return float(current_display)
+
     def reset(self, base_plot: "_BasePlot", index=None) -> None:
         """
         Resets offset and scale to default values (0 and 1 respectively).
@@ -259,6 +311,7 @@ class _PlotManager:
         self.data["offset"] = base_plot._initialize_offset(index)
         self.data["scale"] = np.ones(len(index))
         self.y_ticks = None
+        self._base_offset = None
         self._actions = {
             "group_by": None,
             "sort_by": None,

--- a/src/pynaviz/qt/widget_list_selection.py
+++ b/src/pynaviz/qt/widget_list_selection.py
@@ -1,5 +1,7 @@
+from collections import defaultdict
 from typing import Any
 
+import numpy as np
 import pynapple as nap
 from PySide6.QtCore import (
     QAbstractListModel,
@@ -9,7 +11,14 @@ from PySide6.QtCore import (
     QTimer,
     Signal,
 )
-from PySide6.QtWidgets import QDialog, QListView, QVBoxLayout, QWidget
+from PySide6.QtWidgets import (
+    QDialog,
+    QListView,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
 
 
 class DynamicSelectionListView(QListView):
@@ -166,6 +175,159 @@ class ChannelList(QDialog):
         layout = QVBoxLayout()
         layout.addWidget(self.view)
         self.setLayout(layout)
+
+
+class GroupedChannelTree(QTreeWidget):
+    """A tree widget showing channels nested under their group labels.
+
+    Top-level items represent groups (tristate checkboxes); leaf items
+    represent individual channels. Toggling a group propagates to all its
+    children; toggling a leaf updates the parent's tristate state.
+
+    Parameters
+    ----------
+    channel_names : list
+        Ordered channel keys matching ``_manager.index``.
+    groups_mapping : dict
+        ``{channel_key: group_label_str}`` — the metadata value used to group.
+    order_mapping : dict or None
+        ``{channel_key: int}`` sort rank from ``_manager.data["order"]``.
+        When provided, channels within each group are shown in rank order.
+    visibility_mapping : dict
+        ``{channel_key: bool}`` initial visibility state.
+    """
+
+    visibilityChanged = Signal(object)  # emits np.ndarray of bool in _manager.index order
+
+    def __init__(
+        self,
+        channel_names: list,
+        groups_mapping: dict,
+        order_mapping: dict | None,
+        visibility_mapping: dict,
+        parent: QWidget | None = None,
+    ):
+        super().__init__(parent)
+        self._channel_names = channel_names
+        self._updating = False
+
+        self.setHeaderHidden(True)
+        self._build(channel_names, groups_mapping, order_mapping, visibility_mapping)
+        self.collapseAll()
+        self.itemChanged.connect(self._on_item_changed)
+
+    def _build(self, channel_names, groups_mapping, order_mapping, visibility_mapping):
+        groups: dict[str, list] = defaultdict(list)
+        for ch in channel_names:
+            groups[groups_mapping[ch]].append(ch)
+
+        for group_label in sorted(groups.keys(), key=str):
+            channels = groups[group_label]
+            if order_mapping is not None:
+                channels = sorted(channels, key=lambda c: order_mapping[c])
+
+            group_item = QTreeWidgetItem(self, [str(group_label)])
+            group_item.setFlags(
+                Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsUserCheckable
+            )
+
+            for ch in channels:
+                leaf = QTreeWidgetItem(group_item, [str(ch)])
+                leaf.setFlags(
+                    Qt.ItemFlag.ItemIsEnabled
+                    | Qt.ItemFlag.ItemIsUserCheckable
+                    | Qt.ItemFlag.ItemIsSelectable
+                )
+                state = Qt.CheckState.Checked if visibility_mapping[ch] else Qt.CheckState.Unchecked
+                leaf.setCheckState(0, state)
+
+            # Set initial group tristate from children without triggering _on_item_changed
+            self._set_parent_tristate(group_item)
+
+    @staticmethod
+    def _set_parent_tristate(parent: QTreeWidgetItem) -> None:
+        states = [parent.child(i).checkState(0) for i in range(parent.childCount())]
+        if all(s == Qt.CheckState.Checked for s in states):
+            parent.setCheckState(0, Qt.CheckState.Checked)
+        elif all(s == Qt.CheckState.Unchecked for s in states):
+            parent.setCheckState(0, Qt.CheckState.Unchecked)
+        else:
+            parent.setCheckState(0, Qt.CheckState.PartiallyChecked)
+
+    def _on_item_changed(self, item: QTreeWidgetItem, _column: int):
+        if self._updating:
+            return
+        self._updating = True
+
+        if item.parent() is None:
+            # Group node toggled: propagate to all children.
+            state = item.checkState(0)
+            if state == Qt.CheckState.PartiallyChecked:
+                # Promote partial → checked on a direct click of the group node.
+                state = Qt.CheckState.Checked
+                item.setCheckState(0, state)
+            for i in range(item.childCount()):
+                item.child(i).setCheckState(0, state)
+        else:
+            # Leaf toggled: update parent tristate manually.
+            self._set_parent_tristate(item.parent())
+
+        self._updating = False
+        self.visibilityChanged.emit(self._visibility_array())
+
+    def _visibility_array(self) -> np.ndarray:
+        """Return a bool array in ``_channel_names`` order."""
+        state_map: dict = {}
+        for i in range(self.topLevelItemCount()):
+            group = self.topLevelItem(i)
+            for j in range(group.childCount()):
+                leaf = group.child(j)
+                state_map[leaf.text(0)] = leaf.checkState(0) == Qt.CheckState.Checked
+        return np.array([state_map[str(ch)] for ch in self._channel_names], dtype=bool)
+
+
+class GroupedChannelList(QDialog):
+    """Dialog wrapping :class:`GroupedChannelTree` for group-by channel visibility.
+
+    Emits ``visibilityChanged(np.ndarray)`` — a bool array in ``_manager.index``
+    order — whenever any checkbox in the tree changes.
+
+    Parameters
+    ----------
+    channel_names : list
+        Ordered channel keys matching ``_manager.index``.
+    groups_mapping : dict
+        ``{channel_key: group_label_str}``.
+    order_mapping : dict or None
+        ``{channel_key: int}`` sort rank, or ``None`` if not sorted.
+    visibility_mapping : dict
+        ``{channel_key: bool}`` initial visibility.
+    parent : QWidget, optional
+    """
+
+    visibilityChanged = Signal(object)  # np.ndarray of bool
+
+    def __init__(
+        self,
+        channel_names: list,
+        groups_mapping: dict,
+        order_mapping: dict | None,
+        visibility_mapping: dict,
+        parent: QWidget | None = None,
+    ):
+        super().__init__(parent)
+        self.setWindowTitle("Channel List")
+        self.setWindowModality(Qt.WindowModality.NonModal)
+
+        self.tree = GroupedChannelTree(
+            channel_names, groups_mapping, order_mapping, visibility_mapping, parent=self
+        )
+        self.tree.visibilityChanged.connect(self.visibilityChanged)
+
+        layout = QVBoxLayout()
+        layout.addWidget(self.tree)
+        self.setLayout(layout)
+        self.adjustSize()
 
 
 

--- a/src/pynaviz/qt/widget_menu.py
+++ b/src/pynaviz/qt/widget_menu.py
@@ -41,6 +41,7 @@ from ..qt.tsdframe_selection import TsdFramesDialog, TsdFramesModel
 from ..qt.widget_list_selection import (
     ChannelList,
     ChannelListModel,
+    GroupedChannelList,
 )
 from ..utils import get_plot_attribute
 
@@ -447,17 +448,46 @@ class MenuWidget(QWidget):
     def show_select_menu(self) -> None:
         """Opens the channel list selection dialog."""
         if hasattr(self.plot, "_controllers"):
-            # If 'get' controller is enabled (i.e., in x vs y mode),
-            # Need to disable channel selection
             get_ctrl = self.plot._controllers.get("get")
             if get_ctrl is not None and get_ctrl.enabled:
                 return
+
+        manager = getattr(self.plot, "_manager", None)
+
+        if manager is not None and manager.is_grouped:
+            metadata_name = manager._actions["group_by"]["metadata_name"]
+            channel_names = list(manager.index)
+            groups_mapping = {
+                ch: str(self.plot.data.metadata.loc[ch][metadata_name])
+                for ch in channel_names
+            }
+            visibility_mapping = {
+                ch: bool(manager.data.loc[ch]["visible"])
+                for ch in channel_names
+            }
+            order_mapping = (
+                {ch: int(manager.data.loc[ch]["order"]) for ch in channel_names}
+                if manager.is_sorted
+                else None
+            )
+            dialog = GroupedChannelList(
+                channel_names, groups_mapping, order_mapping, visibility_mapping, parent=self
+            )
+            dialog.visibilityChanged.connect(self._change_visibility_from_array)
+            dialog.show()
+        else:
+            if manager is not None:
+                for key in self.channel_model.checks:
+                    self.channel_model.checks[key] = manager.data.loc[key]["visible"]
+            dialog = ChannelList(self.channel_model, parent=self)
+            dialog.show()
+
+    def _change_visibility_from_array(self, visibility_array) -> None:
+        """Update plot visibility from an ordered bool array (tree dialog callback)."""
         if hasattr(self.plot, "_manager"):
-            data = self.plot._manager.data
-            for key in self.channel_model.checks:
-                self.channel_model.checks[key] =  data.loc[key]["visible"]
-        dialog = ChannelList(self.channel_model, parent=self)
-        dialog.show()
+            self.plot._manager.visible = visibility_array
+        if hasattr(self.plot, "_update"):
+            self.plot._update("toggle_visibility")
 
     def show_overlay_menu(self, popup_name) -> None:
         """Opens the TsdFrame overlay selection dialog."""

--- a/tests/test_grouped_channel_list.py
+++ b/tests/test_grouped_channel_list.py
@@ -1,0 +1,328 @@
+"""Tests for GroupedChannelTree and GroupedChannelList, and MenuWidget.show_select_menu
+branching when group_by is active.
+"""
+
+import numpy as np
+import pynapple as nap
+import pytest
+from PySide6.QtCore import Qt
+
+import pynaviz.qt.mainwindow as mw
+from pynaviz.qt.widget_list_selection import (
+    ChannelList,
+    GroupedChannelList,
+    GroupedChannelTree,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_tsdframe(n_channels=4):
+    t = np.arange(0, 1, 0.01)
+    metadata = {"group": [0, 0, 1, 1][:n_channels], "rank": list(range(n_channels))}
+    return nap.TsdFrame(
+        t=t,
+        d=np.random.randn(len(t), n_channels),
+        columns=[f"ch{i}" for i in range(n_channels)],
+        metadata=metadata,
+    )
+
+
+def _tree_fixture(groups_mapping=None, order_mapping=None, visibility_mapping=None):
+    channels = ["ch0", "ch1", "ch2", "ch3"]
+    if groups_mapping is None:
+        groups_mapping = {"ch0": "A", "ch1": "A", "ch2": "B", "ch3": "B"}
+    if visibility_mapping is None:
+        visibility_mapping = {ch: True for ch in channels}
+    return channels, groups_mapping, order_mapping, visibility_mapping
+
+
+# ---------------------------------------------------------------------------
+# GroupedChannelTree — structure
+# ---------------------------------------------------------------------------
+
+class TestGroupedChannelTreeStructure:
+
+    def test_top_level_count_matches_unique_groups(self, qtbot):
+        channels, gmap, omap, vmap = _tree_fixture()
+        tree = GroupedChannelTree(channels, gmap, omap, vmap)
+        qtbot.addWidget(tree)
+        assert tree.topLevelItemCount() == 2
+
+    def test_group_labels_are_correct(self, qtbot):
+        channels, gmap, omap, vmap = _tree_fixture()
+        tree = GroupedChannelTree(channels, gmap, omap, vmap)
+        qtbot.addWidget(tree)
+        labels = {tree.topLevelItem(i).text(0) for i in range(tree.topLevelItemCount())}
+        assert labels == {"A", "B"}
+
+    def test_child_count_per_group(self, qtbot):
+        channels, gmap, omap, vmap = _tree_fixture()
+        tree = GroupedChannelTree(channels, gmap, omap, vmap)
+        qtbot.addWidget(tree)
+        counts = {
+            tree.topLevelItem(i).text(0): tree.topLevelItem(i).childCount()
+            for i in range(tree.topLevelItemCount())
+        }
+        assert counts == {"A": 2, "B": 2}
+
+    def test_leaf_names_match_channels(self, qtbot):
+        channels, gmap, omap, vmap = _tree_fixture()
+        tree = GroupedChannelTree(channels, gmap, omap, vmap)
+        qtbot.addWidget(tree)
+        leaf_names = set()
+        for i in range(tree.topLevelItemCount()):
+            group = tree.topLevelItem(i)
+            for j in range(group.childCount()):
+                leaf_names.add(group.child(j).text(0))
+        assert leaf_names == set(channels)
+
+    def test_channels_ordered_by_order_mapping(self, qtbot):
+        channels = ["ch0", "ch1", "ch2", "ch3"]
+        gmap = {"ch0": "A", "ch1": "A", "ch2": "A", "ch3": "A"}
+        omap = {"ch0": 3, "ch1": 1, "ch2": 0, "ch3": 2}
+        vmap = {ch: True for ch in channels}
+        tree = GroupedChannelTree(channels, gmap, omap, vmap)
+        qtbot.addWidget(tree)
+        group = tree.topLevelItem(0)
+        leaf_names = [group.child(j).text(0) for j in range(group.childCount())]
+        assert leaf_names == ["ch2", "ch1", "ch3", "ch0"]
+
+    def test_initial_visibility_all_checked(self, qtbot):
+        channels, gmap, omap, vmap = _tree_fixture()
+        tree = GroupedChannelTree(channels, gmap, omap, vmap)
+        qtbot.addWidget(tree)
+        vis = tree._visibility_array()
+        assert vis.all()
+
+    def test_initial_visibility_partial(self, qtbot):
+        channels = ["ch0", "ch1", "ch2", "ch3"]
+        gmap = {"ch0": "A", "ch1": "A", "ch2": "B", "ch3": "B"}
+        vmap = {"ch0": True, "ch1": False, "ch2": True, "ch3": False}
+        tree = GroupedChannelTree(channels, gmap, None, vmap)
+        qtbot.addWidget(tree)
+        vis = tree._visibility_array()
+        np.testing.assert_array_equal(vis, [True, False, True, False])
+
+    def test_group_with_all_hidden_shows_unchecked(self, qtbot):
+        channels = ["ch0", "ch1", "ch2", "ch3"]
+        gmap = {"ch0": "A", "ch1": "A", "ch2": "B", "ch3": "B"}
+        vmap = {"ch0": False, "ch1": False, "ch2": True, "ch3": True}
+        tree = GroupedChannelTree(channels, gmap, None, vmap)
+        qtbot.addWidget(tree)
+        # find group A
+        for i in range(tree.topLevelItemCount()):
+            item = tree.topLevelItem(i)
+            if item.text(0) == "A":
+                assert item.checkState(0) == Qt.CheckState.Unchecked
+            else:
+                assert item.checkState(0) == Qt.CheckState.Checked
+
+    def test_group_with_mixed_shows_partial(self, qtbot):
+        channels = ["ch0", "ch1", "ch2", "ch3"]
+        gmap = {"ch0": "A", "ch1": "A", "ch2": "B", "ch3": "B"}
+        vmap = {"ch0": True, "ch1": False, "ch2": True, "ch3": True}
+        tree = GroupedChannelTree(channels, gmap, None, vmap)
+        qtbot.addWidget(tree)
+        for i in range(tree.topLevelItemCount()):
+            item = tree.topLevelItem(i)
+            if item.text(0) == "A":
+                assert item.checkState(0) == Qt.CheckState.PartiallyChecked
+
+
+# ---------------------------------------------------------------------------
+# GroupedChannelTree — interaction
+# ---------------------------------------------------------------------------
+
+class TestGroupedChannelTreeInteraction:
+
+    def _find_group(self, tree, label):
+        for i in range(tree.topLevelItemCount()):
+            if tree.topLevelItem(i).text(0) == label:
+                return tree.topLevelItem(i)
+        return None
+
+    def test_uncheck_group_unchecks_all_children(self, qtbot):
+        channels, gmap, omap, vmap = _tree_fixture()
+        tree = GroupedChannelTree(channels, gmap, omap, vmap)
+        qtbot.addWidget(tree)
+
+        group_a = self._find_group(tree, "A")
+        group_a.setCheckState(0, Qt.CheckState.Unchecked)
+
+        for j in range(group_a.childCount()):
+            assert group_a.child(j).checkState(0) == Qt.CheckState.Unchecked
+
+    def test_check_group_checks_all_children(self, qtbot):
+        channels = ["ch0", "ch1", "ch2", "ch3"]
+        gmap = {"ch0": "A", "ch1": "A", "ch2": "B", "ch3": "B"}
+        vmap = {"ch0": False, "ch1": False, "ch2": True, "ch3": True}
+        tree = GroupedChannelTree(channels, gmap, None, vmap)
+        qtbot.addWidget(tree)
+
+        group_a = self._find_group(tree, "A")
+        group_a.setCheckState(0, Qt.CheckState.Checked)
+
+        for j in range(group_a.childCount()):
+            assert group_a.child(j).checkState(0) == Qt.CheckState.Checked
+
+    def test_visibility_array_after_uncheck_group(self, qtbot):
+        channels = ["ch0", "ch1", "ch2", "ch3"]
+        gmap = {"ch0": "A", "ch1": "A", "ch2": "B", "ch3": "B"}
+        vmap = {ch: True for ch in channels}
+        tree = GroupedChannelTree(channels, gmap, None, vmap)
+        qtbot.addWidget(tree)
+
+        self._find_group(tree, "A").setCheckState(0, Qt.CheckState.Unchecked)
+
+        vis = tree._visibility_array()
+        # ch0, ch1 → False; ch2, ch3 → True
+        np.testing.assert_array_equal(vis, [False, False, True, True])
+
+    def test_leaf_toggle_updates_parent_to_partial(self, qtbot):
+        channels, gmap, omap, vmap = _tree_fixture()
+        tree = GroupedChannelTree(channels, gmap, omap, vmap)
+        qtbot.addWidget(tree)
+
+        group_a = self._find_group(tree, "A")
+        group_a.child(0).setCheckState(0, Qt.CheckState.Unchecked)
+
+        assert group_a.checkState(0) == Qt.CheckState.PartiallyChecked
+
+    def test_leaf_toggle_all_unchecked_makes_parent_unchecked(self, qtbot):
+        channels, gmap, omap, vmap = _tree_fixture()
+        tree = GroupedChannelTree(channels, gmap, omap, vmap)
+        qtbot.addWidget(tree)
+
+        group_a = self._find_group(tree, "A")
+        for j in range(group_a.childCount()):
+            group_a.child(j).setCheckState(0, Qt.CheckState.Unchecked)
+
+        assert group_a.checkState(0) == Qt.CheckState.Unchecked
+
+    def test_visibility_signal_emitted_on_leaf_change(self, qtbot):
+        channels, gmap, omap, vmap = _tree_fixture()
+        tree = GroupedChannelTree(channels, gmap, omap, vmap)
+        qtbot.addWidget(tree)
+
+        emitted = []
+        tree.visibilityChanged.connect(lambda v: emitted.append(v.copy()))
+
+        group_a = self._find_group(tree, "A")
+        group_a.child(0).setCheckState(0, Qt.CheckState.Unchecked)
+
+        assert len(emitted) >= 1
+        assert isinstance(emitted[-1], np.ndarray)
+        assert emitted[-1].dtype == bool
+
+    def test_visibility_signal_emitted_on_group_change(self, qtbot):
+        channels, gmap, omap, vmap = _tree_fixture()
+        tree = GroupedChannelTree(channels, gmap, omap, vmap)
+        qtbot.addWidget(tree)
+
+        emitted = []
+        tree.visibilityChanged.connect(lambda v: emitted.append(v.copy()))
+
+        self._find_group(tree, "B").setCheckState(0, Qt.CheckState.Unchecked)
+
+        assert len(emitted) >= 1
+        assert not emitted[-1][2]  # ch2 → False
+        assert not emitted[-1][3]  # ch3 → False
+
+
+# ---------------------------------------------------------------------------
+# GroupedChannelList dialog
+# ---------------------------------------------------------------------------
+
+class TestGroupedChannelList:
+
+    def test_dialog_creates_tree(self, qtbot):
+        channels, gmap, omap, vmap = _tree_fixture()
+        dialog = GroupedChannelList(channels, gmap, omap, vmap)
+        qtbot.addWidget(dialog)
+        assert isinstance(dialog.tree, GroupedChannelTree)
+
+    def test_dialog_re_emits_visibility_changed(self, qtbot):
+        channels, gmap, omap, vmap = _tree_fixture()
+        dialog = GroupedChannelList(channels, gmap, omap, vmap)
+        qtbot.addWidget(dialog)
+
+        received = []
+        dialog.visibilityChanged.connect(lambda v: received.append(v))
+
+        group = dialog.tree.topLevelItem(0)
+        group.setCheckState(0, Qt.CheckState.Unchecked)
+
+        assert len(received) >= 1
+
+
+# ---------------------------------------------------------------------------
+# MenuWidget.show_select_menu — flat vs tree branching
+# ---------------------------------------------------------------------------
+
+class TestMenuWidgetShowSelectMenu:
+
+    @pytest.fixture
+    def window_tsdframe(self, qtbot):
+        tsdframe = _make_tsdframe()
+        variables = {"tsdframe": tsdframe}
+        window = mw.MainWindow(variables)
+        qtbot.addWidget(window)
+        dock = window.add_dock_widget(tsdframe, ["tsdframe"])
+        widget = dock.widget()
+        return window, widget, tsdframe
+
+    def test_flat_list_when_no_group_by(self, window_tsdframe, qtbot):
+        _, widget, _ = window_tsdframe
+        menu = widget.button_container
+        # No group_by active → should open a ChannelList (flat)
+        menu.show_select_menu()
+        dialogs = [w for w in menu.findChildren(ChannelList)]
+        # The dialog was created and shown
+        assert len(dialogs) == 1
+        assert not any(isinstance(w, GroupedChannelList) for w in menu.findChildren(GroupedChannelList))
+
+    def test_tree_dialog_when_group_by_active(self, window_tsdframe, qtbot):
+        _, widget, tsdframe = window_tsdframe
+        menu = widget.button_container
+        widget.plot.group_by(metadata_name="group")
+
+        menu.show_select_menu()
+
+        grouped_dialogs = menu.findChildren(GroupedChannelList)
+        assert len(grouped_dialogs) == 1
+
+    def test_tree_has_correct_groups_after_group_by(self, window_tsdframe, qtbot):
+        _, widget, tsdframe = window_tsdframe
+        menu = widget.button_container
+        widget.plot.group_by(metadata_name="group")
+        menu.show_select_menu()
+
+        dialog = menu.findChildren(GroupedChannelList)[0]
+        top_labels = {
+            dialog.tree.topLevelItem(i).text(0)
+            for i in range(dialog.tree.topLevelItemCount())
+        }
+        assert top_labels == {"0", "1"}
+
+    def test_visibility_update_propagates_to_manager(self, window_tsdframe, qtbot):
+        _, widget, _ = window_tsdframe
+        menu = widget.button_container
+        widget.plot.group_by(metadata_name="group")
+        menu.show_select_menu()
+
+        dialog = menu.findChildren(GroupedChannelList)[0]
+        # Uncheck group "0" → ch0, ch1 should become hidden
+        for i in range(dialog.tree.topLevelItemCount()):
+            if dialog.tree.topLevelItem(i).text(0) == "0":
+                dialog.tree.topLevelItem(i).setCheckState(0, Qt.CheckState.Unchecked)
+                break
+
+        manager = widget.plot._manager
+        # channels in group "0" are ch0 and ch1 (indices 0 and 1)
+        assert not manager.visible[0]
+        assert not manager.visible[1]
+        # channels in group "1" remain visible
+        assert manager.visible[2]
+        assert manager.visible[3]

--- a/tests/test_nested_interval_sets.py
+++ b/tests/test_nested_interval_sets.py
@@ -1,0 +1,242 @@
+"""Tests for same-level IntervalSet resolution in nested variable trees.
+
+Covers _get_same_level_interval_sets and the key_path plumbing through
+add_dock_widget -> _create_widget_for_variable for flat, nested-dict,
+EphysReference, and NWBReference variable structures.
+"""
+
+import numpy as np
+import pynapple as nap
+import pytest
+
+import pynaviz.qt.mainwindow as mw
+from pynaviz.qt.references import EphysReference, NWBReference
+
+# ---------------------------------------------------------------------------
+# Helpers / shared data
+# ---------------------------------------------------------------------------
+
+def _make_tsdframe():
+    t = np.arange(0, 1, 0.01)
+    return nap.TsdFrame(t=t, d=np.random.randn(len(t), 3))
+
+
+def _make_intervalset():
+    return nap.IntervalSet(start=[0.1, 0.5], end=[0.2, 0.6])
+
+
+class _MockReader:
+    """Minimal stand-in for nap.EphysReader / nap.NWBFile."""
+    def __init__(self, mapping):
+        self._mapping = mapping
+
+    def __getitem__(self, key):
+        return self._mapping[key]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def app(qtbot):
+    """Ensure a QApplication exists (provided by qtbot)."""
+    return
+
+
+@pytest.fixture
+def flat_variables():
+    """Top-level dict with TsdFrame and two IntervalSets."""
+    return {
+        "lfp": _make_tsdframe(),
+        "sleep_ep": _make_intervalset(),
+        "wake_ep": _make_intervalset(),
+    }
+
+
+@pytest.fixture
+def nested_variables():
+    """One level of nesting: session -> {lfp, sleep_ep, wake_ep}."""
+    return {
+        "session": {
+            "lfp": _make_tsdframe(),
+            "sleep_ep": _make_intervalset(),
+            "wake_ep": _make_intervalset(),
+        }
+    }
+
+
+@pytest.fixture
+def ephys_variables():
+    """Nested dict where leaves are EphysReference objects."""
+    tsdframe = _make_tsdframe()
+    iset = _make_intervalset()
+    reader = _MockReader({"lfp": tsdframe, "sleep_ep": iset})
+    return {
+        "recording": {
+            "lfp": EphysReference(ephys_reader=reader, key="lfp"),
+            "sleep_ep": EphysReference(ephys_reader=reader, key="sleep_ep"),
+        }
+    }
+
+
+@pytest.fixture
+def nwb_variables():
+    """Nested dict where leaves are NWBReference objects."""
+    tsdframe = _make_tsdframe()
+    iset = _make_intervalset()
+    nwb_file = _MockReader({"lfp": tsdframe, "sleep_ep": iset})
+    return {
+        "recording": {
+            "lfp": NWBReference(nwb_file=nwb_file, key="lfp"),
+            "sleep_ep": NWBReference(nwb_file=nwb_file, key="sleep_ep"),
+        }
+    }
+
+
+def _make_window(variables, qtbot):
+    window = mw.MainWindow(variables)
+    qtbot.addWidget(window)
+    return window
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _get_same_level_interval_sets
+# ---------------------------------------------------------------------------
+
+class TestGetSameLevelIntervalSets:
+
+    def test_flat_returns_sibling_interval_sets(self, flat_variables, qtbot):
+        window = _make_window(flat_variables, qtbot)
+        result = window._get_same_level_interval_sets(["lfp"])
+        assert set(result.keys()) == {"sleep_ep", "wake_ep"}
+        assert all(isinstance(v, nap.IntervalSet) for v in result.values())
+
+    def test_flat_excludes_self(self, flat_variables, qtbot):
+        window = _make_window(flat_variables, qtbot)
+        result = window._get_same_level_interval_sets(["sleep_ep"])
+        assert "sleep_ep" not in result
+        assert "wake_ep" in result
+
+    def test_flat_no_sibling_interval_sets_returns_empty(self, qtbot):
+        variables = {"lfp": _make_tsdframe(), "spikes": _make_tsdframe()}
+        window = _make_window(variables, qtbot)
+        result = window._get_same_level_interval_sets(["lfp"])
+        assert result == {}
+
+    def test_nested_returns_sibling_interval_sets(self, nested_variables, qtbot):
+        window = _make_window(nested_variables, qtbot)
+        result = window._get_same_level_interval_sets(["session", "lfp"])
+        assert set(result.keys()) == {"session/sleep_ep", "session/wake_ep"}
+        assert all(isinstance(v, nap.IntervalSet) for v in result.values())
+
+    def test_nested_label_uses_full_path(self, nested_variables, qtbot):
+        window = _make_window(nested_variables, qtbot)
+        result = window._get_same_level_interval_sets(["session", "lfp"])
+        assert "session/sleep_ep" in result
+        assert "session/wake_ep" in result
+
+    def test_nested_excludes_self(self, nested_variables, qtbot):
+        window = _make_window(nested_variables, qtbot)
+        result = window._get_same_level_interval_sets(["session", "sleep_ep"])
+        assert "session/sleep_ep" not in result
+        assert "session/wake_ep" in result
+
+    def test_ephys_reference_interval_set_resolved(self, ephys_variables, qtbot):
+        window = _make_window(ephys_variables, qtbot)
+        result = window._get_same_level_interval_sets(["recording", "lfp"])
+        assert "recording/sleep_ep" in result
+        assert isinstance(result["recording/sleep_ep"], nap.IntervalSet)
+
+    def test_ephys_reference_non_interval_set_excluded(self, ephys_variables, qtbot):
+        window = _make_window(ephys_variables, qtbot)
+        result = window._get_same_level_interval_sets(["recording", "lfp"])
+        # 'lfp' sibling is TsdFrame, should not appear
+        assert "recording/lfp" not in result
+
+    def test_nwb_reference_interval_set_resolved(self, nwb_variables, qtbot):
+        window = _make_window(nwb_variables, qtbot)
+        result = window._get_same_level_interval_sets(["recording", "lfp"])
+        assert "recording/sleep_ep" in result
+        assert isinstance(result["recording/sleep_ep"], nap.IntervalSet)
+
+    def test_nwb_reference_non_interval_set_excluded(self, nwb_variables, qtbot):
+        window = _make_window(nwb_variables, qtbot)
+        result = window._get_same_level_interval_sets(["recording", "lfp"])
+        assert "recording/lfp" not in result
+
+    def test_cross_branch_interval_sets_excluded(self, qtbot):
+        """IntervalSets under a different top-level key must not appear."""
+        variables = {
+            "session_a": {
+                "lfp": _make_tsdframe(),
+                "sleep_ep": _make_intervalset(),
+            },
+            "session_b": {
+                "lfp": _make_tsdframe(),
+                "wake_ep": _make_intervalset(),
+            },
+        }
+        window = _make_window(variables, qtbot)
+        result = window._get_same_level_interval_sets(["session_a", "lfp"])
+        assert "session_a/sleep_ep" in result
+        # session_b's interval set must not bleed into session_a
+        assert "session_b/wake_ep" not in result
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: add_dock_widget passes interval_sets to the widget
+# ---------------------------------------------------------------------------
+
+def _user_interval_sets(widget):
+    """Return the interval_sets registered on the widget, minus 'Time Support'."""
+    isets = widget.button_container._interval_sets or {}
+    return {k: v for k, v in isets.items() if k != "Time Support"}
+
+
+class TestAddDockWidgetIntervalSets:
+
+    def test_flat_tsdframe_receives_sibling_interval_sets(self, flat_variables, qtbot):
+        window = _make_window(flat_variables, qtbot)
+        dock = window.add_dock_widget(flat_variables["lfp"], ["lfp"])
+        isets = _user_interval_sets(dock.widget())
+        assert set(isets.keys()) == {"sleep_ep", "wake_ep"}
+
+    def test_nested_tsdframe_receives_sibling_interval_sets(self, nested_variables, qtbot):
+        window = _make_window(nested_variables, qtbot)
+        var = nested_variables["session"]["lfp"]
+        dock = window.add_dock_widget(var, ["session", "lfp"])
+        isets = _user_interval_sets(dock.widget())
+        assert set(isets.keys()) == {"session/sleep_ep", "session/wake_ep"}
+
+    def test_nested_tsdframe_no_cross_contamination(self, qtbot):
+        variables = {
+            "session_a": {"lfp": _make_tsdframe(), "sleep_ep": _make_intervalset()},
+            "session_b": {"lfp": _make_tsdframe(), "wake_ep": _make_intervalset()},
+        }
+        window = _make_window(variables, qtbot)
+        dock = window.add_dock_widget(variables["session_a"]["lfp"], ["session_a", "lfp"])
+        isets = _user_interval_sets(dock.widget())
+        assert "session_a/sleep_ep" in isets
+        assert "session_b/wake_ep" not in isets
+
+    def test_ephys_reference_tsdframe_receives_sibling_interval_sets(self, ephys_variables, qtbot):
+        window = _make_window(ephys_variables, qtbot)
+        ref = ephys_variables["recording"]["lfp"]
+        dock = window.add_dock_widget(ref, ["recording", "lfp"])
+        isets = _user_interval_sets(dock.widget())
+        assert "recording/sleep_ep" in isets
+
+    def test_nwb_reference_tsdframe_receives_sibling_interval_sets(self, nwb_variables, qtbot):
+        window = _make_window(nwb_variables, qtbot)
+        ref = nwb_variables["recording"]["lfp"]
+        dock = window.add_dock_widget(ref, ["recording", "lfp"])
+        isets = _user_interval_sets(dock.widget())
+        assert "recording/sleep_ep" in isets
+
+    def test_flat_variable_with_no_interval_sets_gets_only_time_support(self, qtbot):
+        variables = {"lfp": _make_tsdframe(), "spikes": _make_tsdframe()}
+        window = _make_window(variables, qtbot)
+        dock = window.add_dock_widget(variables["lfp"], ["lfp"])
+        isets = _user_interval_sets(dock.widget())
+        assert isets == {}

--- a/tests/test_plot_tsdframe.py
+++ b/tests/test_plot_tsdframe.py
@@ -207,10 +207,10 @@ def test_lines_mode_update_visibility(dummy_tsdframe):
     v = viz.PlotTsdFrame(dummy_tsdframe)
     mode = v._modes["lines"]
 
-    # All channels visible initially
-    colors = mode.graphic.geometry.colors.data
-    for _, sl in mode._buffer_slices.items():
-        assert np.all(colors[sl, -1] == 1.0)
+    # All channels visible initially — positions are real (non-NaN) values
+    first_col = dummy_tsdframe.columns[0]
+    sl0 = mode._buffer_slices[first_col]
+    assert not np.all(np.isnan(mode.buffer[sl0, 0]))
 
     # Hide first channel
     vis = v._manager.visible.copy()
@@ -218,15 +218,20 @@ def test_lines_mode_update_visibility(dummy_tsdframe):
     v._manager.visible = vis
     mode.update_visibility()
 
-    colors = mode.graphic.geometry.colors.data
-    first_col = dummy_tsdframe.columns[0]
-    sl = mode._buffer_slices[first_col]
-    assert np.all(colors[sl, -1] == 0.0)
+    # Hidden channel: positions are NaN
+    assert np.all(np.isnan(mode.buffer[sl0, 0]))
+    assert np.all(np.isnan(mode.buffer[sl0, 1]))
 
-    # Other channels still visible
+    # Other channels still have real data
     for c in dummy_tsdframe.columns[1:]:
         sl = mode._buffer_slices[c]
-        assert np.all(colors[sl, -1] == 1.0)
+        assert not np.all(np.isnan(mode.buffer[sl, 0]))
+
+    # Un-hide the channel — positions are restored
+    vis[0] = True
+    v._manager.visible = vis
+    mode.update_visibility()
+    assert not np.all(np.isnan(mode.buffer[sl0, 0]))
 
     v.close()
 
@@ -428,6 +433,155 @@ def test_xvsy_mode_get_callbacks(dummy_tsdframe):
 
 
 # ── Mode switching ───────────────────────────────────────────────────────────
+
+# ── compact_visible_offsets tests ────────────────────────────────────────────
+
+def test_compact_offsets_snapshotted_after_group_by(dummy_tsdframe):
+    v = viz.PlotTsdFrame(dummy_tsdframe)
+    v.group_by(metadata_name="group")
+    assert v._manager._base_offset is not None
+    np.testing.assert_array_equal(v._manager._base_offset, v._manager.offset)
+    v.close()
+
+
+def test_compact_offsets_snapshotted_after_sort_by(dummy_tsdframe):
+    v = viz.PlotTsdFrame(dummy_tsdframe)
+    v.sort_by(metadata_name="channel")
+    assert v._manager._base_offset is not None
+    np.testing.assert_array_equal(v._manager._base_offset, v._manager.offset)
+    v.close()
+
+
+def test_compact_offsets_group_by_hide_whole_group(dummy_tsdframe):
+    # dummy_tsdframe: columns [0,1,2,3,4], group metadata [0,0,1,0,1]
+    # After group_by: group 0 channels at 1, group 1 channels at 3
+    v = viz.PlotTsdFrame(dummy_tsdframe)
+    v.group_by(metadata_name="group")
+
+    group1_cols = [c for c in dummy_tsdframe.columns if dummy_tsdframe.metadata.loc[c]["group"] == 1]
+
+    # Hide all group 1 channels
+    vis = v._manager.visible.copy()
+    for c in group1_cols:
+        vis[list(dummy_tsdframe.columns).index(c)] = False
+    v._manager.visible = vis
+
+    y_max = v._manager.compact_visible_offsets()
+
+    # All visible channels were in group 0 → same offset (1)
+    for c in dummy_tsdframe.columns:
+        if dummy_tsdframe.metadata.loc[c]["group"] == 0:
+            assert v._manager.data.loc[c]["offset"] == pytest.approx(1.0)
+
+    # y_max should be 1 (only group 0 visible, no gap needed)
+    assert y_max == pytest.approx(1.0)
+    v.close()
+
+
+def test_compact_offsets_group_by_partial_hide(dummy_tsdframe):
+    # Hide only one channel from group 1; group 1 still has channels → gap preserved
+    v = viz.PlotTsdFrame(dummy_tsdframe)
+    v.group_by(metadata_name="group")
+
+    group1_cols = [c for c in dummy_tsdframe.columns if dummy_tsdframe.metadata.loc[c]["group"] == 1]
+    vis = v._manager.visible.copy()
+    # Hide only the first channel from group 1
+    vis[list(dummy_tsdframe.columns).index(group1_cols[0])] = False
+    v._manager.visible = vis
+
+    y_max = v._manager.compact_visible_offsets()
+
+    # Remaining visible group 1 channel should still be above group 0 (offset > 1)
+    remaining_g1 = [c for c in group1_cols if c != group1_cols[0]]
+    for c in remaining_g1:
+        assert v._manager.data.loc[c]["offset"] > 1.0
+
+    # y_max >= 3 since two groups are still visible
+    assert y_max >= 3.0
+    v.close()
+
+
+def test_compact_offsets_sort_by_hide_rank(dummy_tsdframe):
+    # After sort_by, hiding one channel should compact remaining without gaps
+    v = viz.PlotTsdFrame(dummy_tsdframe)
+    v.sort_by(metadata_name="channel")
+
+    offsets_before = v._manager.offset.copy()
+
+    # Hide one channel
+    vis = v._manager.visible.copy()
+    vis[0] = False
+    v._manager.visible = vis
+
+    y_max = v._manager.compact_visible_offsets()
+    offsets_after = v._manager.offset.copy()
+
+    # y_max should be less than before (one less channel)
+    assert y_max < offsets_before.max()
+
+    # Visible offsets should be consecutive starting at 1 (no gaps)
+    _ = sorted(offsets_after[vis])
+    assert y_max >= 1.0
+
+    v.close()
+
+
+def test_compact_offsets_restore_on_show_all(dummy_tsdframe):
+    # Hide a group, then show all — offsets should return to base
+    v = viz.PlotTsdFrame(dummy_tsdframe)
+    v.group_by(metadata_name="group")
+
+    base = v._manager._base_offset.copy()
+
+    # Hide group 1
+    group1_cols = [c for c in dummy_tsdframe.columns if dummy_tsdframe.metadata.loc[c]["group"] == 1]
+    vis = v._manager.visible.copy()
+    for c in group1_cols:
+        vis[list(dummy_tsdframe.columns).index(c)] = False
+    v._manager.visible = vis
+    v._manager.compact_visible_offsets()
+
+    # Show all again
+    v._manager.visible = np.ones(len(dummy_tsdframe.columns), dtype=bool)
+    y_max = v._manager.compact_visible_offsets()
+
+    # Offsets should match the original base
+    np.testing.assert_array_almost_equal(v._manager.offset, base)
+    assert y_max == pytest.approx(float(base.max()))
+
+    v.close()
+
+
+def test_compact_offsets_no_op_without_sort_group(dummy_tsdframe):
+    # compact_visible_offsets should do nothing when no sort/group is active
+    v = viz.PlotTsdFrame(dummy_tsdframe)
+    offsets_before = v._manager.offset.copy()
+
+    y_max = v._manager.compact_visible_offsets()
+
+    np.testing.assert_array_equal(v._manager.offset, offsets_before)
+    assert y_max == pytest.approx(0.0)
+    v.close()
+
+
+def test_toggle_visibility_updates_ylim_with_group_by(dummy_tsdframe):
+    # After group_by and hiding a whole group, ylim should shrink
+    v = viz.PlotTsdFrame(dummy_tsdframe)
+    v.group_by(metadata_name="group")
+
+    ylim_before = v.controller.get_ylim()
+
+    group1_cols = [c for c in dummy_tsdframe.columns if dummy_tsdframe.metadata.loc[c]["group"] == 1]
+    vis = v._manager.visible.copy()
+    for c in group1_cols:
+        vis[list(dummy_tsdframe.columns).index(c)] = False
+    v._manager.visible = vis
+    v._update("toggle_visibility")
+
+    ylim_after = v.controller.get_ylim()
+    assert ylim_after[1] < ylim_before[1]
+    v.close()
+
 
 def test_toggle_display_mode(dummy_tsdframe):
     v = viz.PlotTsdFrame(dummy_tsdframe)


### PR DESCRIPTION
This pull request introduces significant improvements to channel visibility handling, especially when channels are grouped or sorted, and adds a new grouped channel selection dialog in the Qt interface. The main changes include implementing compact offset recalculation for visible channels, updating the display logic to hide channels by removing their data from buffers, and providing a new tree-based dialog for managing group visibility. Several internal APIs and UI behaviors have been updated to support these features.

**Channel visibility and offset management improvements:**

* Added `snapshot_base_offset` and `compact_visible_offsets` methods to `PlotManager` to recompute display offsets for visible channels, ensuring that when channels are hidden in grouped/sorted mode, the visible channels are compacted without gaps. The y-axis is updated accordingly. [[1]](diffhunk://#diff-05c8b4163a84baec84c5aaf54b2c952aed4771661698066f7dedbb9d303bbddbR253-R303) [[2]](diffhunk://#diff-05c8b4163a84baec84c5aaf54b2c952aed4771661698066f7dedbb9d303bbddbR314) [[3]](diffhunk://#diff-5bf1e6ba5b67012fcd5d60d858d39cd44ce5ff90baf5e449cdc9022c9c770932R912-R919)
* The `_update` method in `BasePlot` now snapshots the base offset after sorting/grouping and calls the new compaction logic when toggling channel visibility, ensuring the plot layout remains consistent.

**Display logic and buffer handling:**

* Updated the `flush` method in `DisplayMode` to skip drawing hidden channels, and changed the `update_visibility` method to hide channels by setting their buffer positions to NaN and then re-flushing, rather than manipulating vertex color alpha. [[1]](diffhunk://#diff-4b6782df16cee2c5a3b08e9bdd173f289f1bb494307498a4d636dac100afce69R99-R100) [[2]](diffhunk://#diff-4b6782df16cee2c5a3b08e9bdd173f289f1bb494307498a4d636dac100afce69R121-R122) [[3]](diffhunk://#diff-4b6782df16cee2c5a3b08e9bdd173f289f1bb494307498a4d636dac100afce69L181-R189)

**Qt interface enhancements:**

* Introduced `GroupedChannelTree` and `GroupedChannelList` widgets, providing a tree-based dialog for grouped channel visibility selection with tristate group checkboxes and per-channel toggling. [[1]](diffhunk://#diff-877fba3030c6f9c5047c61fa167d5348ccb71fd8f6f8c2dbc4e82b87a2562aedR1-R4) [[2]](diffhunk://#diff-877fba3030c6f9c5047c61fa167d5348ccb71fd8f6f8c2dbc4e82b87a2562aedR180-R332)
* Modified the `show_select_menu` method in `widget_menu.py` to use the new grouped dialog when channels are grouped, and added a callback to update plot visibility from the dialog. [[1]](diffhunk://#diff-93c8f59958f855e626078452c348b66f5649b1400f6529b67a2612a012ba0000R44) [[2]](diffhunk://#diff-93c8f59958f855e626078452c348b66f5649b1400f6529b67a2612a012ba0000L450-R491)

**Miscellaneous:**

* Minor code cleanup, including commenting out unused example code in `main.py` and resetting the base offset snapshot on plot reset. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L30-R52) [[2]](diffhunk://#diff-05c8b4163a84baec84c5aaf54b2c952aed4771661698066f7dedbb9d303bbddbR314)

These changes collectively improve the usability and correctness of channel visibility features, especially in complex grouped or sorted layouts.