### PR TITLE
layout persistence

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,5 +51,14 @@ tsdframe = nap.TsdFrame(
 # df[y_col] = df[y_col]*-1 + 480 # Flipping y axis
 # skeleton = nap.TsdFrame(t=df.index.values/30, d=df.values, columns=df.columns)
 
-scope(globals())
-
+scope(
+    {"tsd1": tsd1,
+     "tsd2": tsd2,
+     "tsd3": tsd3,
+     "tsg": tsg,
+     "tsdframe": tsdframe,
+     # "pose": pose,
+     # "tsdtensor": tsdtensor,
+     # "iset": iset,
+     }
+)

--- a/src/pynaviz/qt/layout_manager.py
+++ b/src/pynaviz/qt/layout_manager.py
@@ -67,7 +67,7 @@ class LayoutManagerMixin:
         self._n_dock_open = 0
         assert len(self.ctrl_group._controller_group) == 0, "Controller group not empty after removing all docks."
 
-    def _restore_docks(self, docks_payload: list[dict]) -> dict[str, QDockWidget]:
+    def _restore_docks(self, docks_payload: list[dict], verbose: bool = True) -> dict[str, QDockWidget]:
         """Recreate each dock from the payload, skipping missing variables.
 
         Returns a mapping from the saved dock name to the live QDockWidget after
@@ -87,9 +87,11 @@ class LayoutManagerMixin:
         for widget in docks_payload:
             var = _get_variable_from_key_path(self.variables, widget['key_path'])
             if var is None:
-                print(f"Variable '{widget['name']}' not found. Skipping dock.")
+                if verbose:
+                    print(f"Variable '{widget['name']}' not found. Skipping dock.")
                 continue
-            print(f"Adding var from path {widget['key_path']}.")
+            if verbose:
+                print(f"Adding var from path {widget['key_path']}.")
             self.add_dock_widget(var, widget['key_path'], state_dict=widget["state_dict"])
             dock_name = self._get_current_dock_name(widget['name'])
             dock = self.findChild(QDockWidget, dock_name)
@@ -132,27 +134,29 @@ class LayoutManagerMixin:
         if current_time is not None:
             self.ctrl_group.set_interval(start=current_time, end=None)
 
-    def _restore_geometry(self, payload: dict):
+    def _restore_geometry(self, payload: dict, verbose: bool = True):
         """Restore Qt window geometry and dock layout from the payload."""
         geom = QByteArray.fromBase64(payload["geometry_b64"].encode("ascii"))
         state = QByteArray.fromBase64(payload["state_b64"].encode("ascii"))
         try:
             self.restoreGeometry(geom)
             ok = self.restoreState(state, payload.get("version", 0))
-            print("restoreState ok:", ok)
+            if verbose:
+                print("restoreState ok:", ok)
         except Exception as e:
-            print("Error restoring layout:", e)
+            if verbose:
+                print("Error restoring layout:", e)
 
-    def _restore_layout(self, file_name):
+    def _restore_layout(self, file_name, verbose: bool = True):
         with open(file_name, "r", encoding="utf-8") as f:
             payload = json.load(f)
 
         self._clear_layout()
         self._load_multiple_files(payload.get("file_paths", []))
         docks_payload = payload.get("docks", [])
-        saved_to_dock = self._restore_docks(docks_payload)
+        saved_to_dock = self._restore_docks(docks_payload, verbose=verbose)
         self._restore_views(docks_payload, saved_to_dock)
-        self._restore_geometry(payload)
+        self._restore_geometry(payload, verbose=verbose)
 
     def _get_plot_state(self, plot):
         """Collect plot state, remapping auto-generated labels to variable names.
@@ -220,8 +224,9 @@ class LayoutManagerMixin:
         }
         return payload
 
-    def _save_layout(self, file_name: str | pathlib.Path | None = None):
-        print("Saving layout...")
+    def _save_layout(self, file_name: str | pathlib.Path | None = None, verbose: bool = True):
+        if verbose:
+            print("Saving layout...")
         if file_name is None:
             dt = datetime.now().strftime("%Y-%m-%d_%H-%M")
             default_file = os.path.join(os.getcwd(), f"layout_{dt}.json")
@@ -240,4 +245,5 @@ class LayoutManagerMixin:
 
             with open(file_name, "w", encoding="utf-8") as f:
                 json.dump(payload, f, indent=2)
-            print(f"Layout saved to {file_name}")
+            if verbose:
+                print(f"Layout saved to {file_name}")

--- a/src/pynaviz/qt/mainwindow.py
+++ b/src/pynaviz/qt/mainwindow.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 import sys
+import tempfile
 from typing import Any, Literal, Union
 
 import pynapple as nap
@@ -38,6 +39,11 @@ from .widget_plot import (
     VideoHandler,
     VideoWidget,
 )
+
+
+def _session_layout_path() -> pathlib.Path:
+    """Return the per-process temp file used to persist the layout across scope() calls."""
+    return pathlib.Path(tempfile.gettempdir()) / f"pynaviz_session_{os.getpid()}.json"
 
 
 def _apply_format_profile(widget, format_profiles: dict) -> None:
@@ -187,7 +193,8 @@ class MainWindow(LayoutManagerMixin, QMainWindow):
 
         # Loading layout if provided
         if layout_path is not None and os.path.isfile(layout_path):
-            self._restore_layout(layout_path)
+            verbose = pathlib.Path(layout_path) != _session_layout_path()
+            self._restore_layout(layout_path, verbose=verbose)
 
     # ------------------------------------------------------------------
     # Menu bar & status bar
@@ -609,6 +616,7 @@ class MainWindow(LayoutManagerMixin, QMainWindow):
 
     def closeEvent(self, event: QEvent):
         """Handle the close event to ensure proper cleanup."""
+        self._save_layout(file_name=_session_layout_path(), verbose=False)
         for dock in self.findChildren(QDockWidget):
             if dock.objectName() != "VariablesDock":
                 self._cleanup_and_close_dock(dock)
@@ -683,6 +691,11 @@ def scope(variables: Union[dict, list, tuple, str], layout_path: str = None, eph
     """
     variables = get_pynapple_variables(variables, ephys_format=ephys_format)
 
+    if layout_path is None:
+        session_file = _session_layout_path()
+        if session_file.exists():
+            layout_path = str(session_file)
+
     global app
     app = QApplication.instance()
     if app is None:
@@ -700,6 +713,8 @@ def scope(variables: Union[dict, list, tuple, str], layout_path: str = None, eph
     gui = MainWindow(variables=variables, layout_path=layout_path)
 
     gui.show()
+    gui.raise_()
+    gui.activateWindow()
 
     app.exit(app.exec())
 


### PR DESCRIPTION
This pull request improves the layout management and user experience in the PyNaviz Qt interface by adding verbose logging options, enhancing session persistence for window layouts, and refining how layouts are restored and saved. The main changes are divided into two themes: session layout persistence and improved logging for layout operations.

**Session layout persistence and restoration:**

* Introduced a per-process temporary file (using `_session_layout_path`) to persist the window layout across `scope()` calls, ensuring that the user's layout is restored automatically if available (`src/pynaviz/qt/mainwindow.py`) (F1771eebL41R41, F1771eebL691R691).
* Modified the `MainWindow` class to automatically load the session layout if no explicit `layout_path` is provided and to save the layout to the session file on close, improving user experience (`src/pynaviz/qt/mainwindow.py`) (F1771eebL193R193, F1771eebL616R616).

**Improved logging and verbosity controls:**

* Added a `verbose` parameter to layout management methods (`_restore_docks`, `_restore_geometry`, `_restore_layout`, `_save_layout`) to control logging output, making it easier to debug layout restoration and saving processes (`src/pynaviz/qt/layout_manager.py`) ([src/pynaviz/qt/layout_manager.pyL70-R70](diffhunk://#diff-a7c9bd04f0da118e2118cad1a72f785ef033bce2bf6bf8dfa60e6f11734f19f6L70-R70), Fd130904L134R134, Fd130904L224R224, Fd130904L245R245).
* Updated the logic so that verbose logging is enabled only when not loading from the session file, reducing console clutter for typical usage (`src/pynaviz/qt/mainwindow.py`) (F1771eebL193R193).

Other minor changes include raising and activating the main window on show for improved window focus (`src/pynaviz/qt/mainwindow.py`) (F1771eebL713R713), and updating the `scope()` call in `main.py` to use explicit variable mapping.