### PR TITLE
adding time bar

### DIFF
--- a/main.py
+++ b/main.py
@@ -40,8 +40,8 @@ tsdframe = nap.TsdFrame(
 # iset = nap.IntervalSet(start=np.arange(0, 1000, 10), end=np.arange(5, 1005, 10))
 #
 #
-# video_path = "docs/examples/m3v1mp4.mp4"
-# v = viz.VideoHandler(video_path)
+video_path = "docs/examples/m3v1mp4.mp4"
+v = viz.VideoHandler(video_path)
 #
 #
 # df = pd.read_hdf("docs/examples/m3v1mp4DLC_Resnet50_openfieldOct30shuffle1_snapshot_best-70.h5")
@@ -51,5 +51,5 @@ tsdframe = nap.TsdFrame(
 # df[y_col] = df[y_col]*-1 + 480 # Flipping y axis
 # skeleton = nap.TsdFrame(t=df.index.values/30, d=df.values, columns=df.columns)
 
-scope(globals())
+scope({"tsd1": tsd1, "tsd2": tsd2, "tsd3": tsd3, "tsg": tsg, "tsdframe": tsdframe, "video": v})
 

--- a/src/pynaviz/qt/mainwindow.py
+++ b/src/pynaviz/qt/mainwindow.py
@@ -5,7 +5,7 @@ from typing import Any, Literal, Union
 
 import pynapple as nap
 from PySide6.QtCore import QByteArray, QEvent, QPoint, QSize, Qt, QTimer
-from PySide6.QtGui import QAction, QIcon, QKeySequence, QPixmap, QShortcut
+from PySide6.QtGui import QAction, QColor, QIcon, QKeySequence, QPainter, QPixmap, QShortcut
 from PySide6.QtWidgets import (
     QApplication,
     QComboBox,
@@ -16,10 +16,67 @@ from PySide6.QtWidgets import (
     QLabel,
     QMainWindow,
     QPushButton,
+    QSlider,
     QStatusBar,
     QStyle,
+    QStyleOptionSlider,
     QWidget,
 )
+
+_TIMEBAR_RESOLUTION = 1_000_000
+
+
+class _TimeSlider(QSlider):
+    """Horizontal slider with click-to-seek and a view-window indicator band."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._view_start_frac: float = 0.0
+        self._view_end_frac: float = 0.0
+
+    def set_view_window(self, start_frac: float, end_frac: float) -> None:
+        """Set the shaded band that shows the currently visible time window."""
+        self._view_start_frac = max(0.0, min(1.0, start_frac))
+        self._view_end_frac = max(0.0, min(1.0, end_frac))
+        self.update()
+
+    def _groove_rect(self):
+        opt = QStyleOptionSlider()
+        self.initStyleOption(opt)
+        return self.style().subControlRect(
+            QStyle.ComplexControl.CC_Slider,
+            opt,
+            QStyle.SubControl.SC_SliderGroove,
+            self,
+        )
+
+    def paintEvent(self, event):
+        super().paintEvent(event)
+        if self._view_end_frac <= self._view_start_frac:
+            return
+        groove = self._groove_rect()
+        x1 = groove.x() + int(self._view_start_frac * groove.width())
+        x2 = groove.x() + int(self._view_end_frac * groove.width())
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        painter.fillRect(x1, groove.y(), x2 - x1, groove.height(), QColor(255, 255, 255, 80))
+        painter.end()
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.MouseButton.LeftButton:
+            groove = self._groove_rect()
+            click_x = int(event.position().x()) - groove.x()
+            value = QStyle.sliderValueFromPosition(
+                self.minimum(), self.maximum(), click_x, groove.width()
+            )
+            self.setValue(value)
+        super().mousePressEvent(event)
+
+    def wheelEvent(self, event):
+        ticks = event.angleDelta().y() / 120  # standard wheel tick = 120 units
+        step = int(ticks * _TIMEBAR_RESOLUTION / 100)  # 1 % of range per tick
+        self.setValue(self.value() + step)
+        event.accept()
 
 from ..controller_group import ControllerGroup
 from ..format_profiles import FORMAT_PROFILES
@@ -269,7 +326,31 @@ class MainWindow(LayoutManagerMixin, QMainWindow):
         self.time_unit_combo.currentIndexChanged.connect(self._on_unit_changed)
         bottom_layout.addWidget(self.time_unit_combo)
 
-        status_bar.addWidget(bottom_container)
+        # --- Time bar (scrubber) ---
+        self.time_slider = _TimeSlider(Qt.Orientation.Horizontal)
+        self.time_slider.setRange(0, _TIMEBAR_RESOLUTION)
+        self.time_slider.setMinimumHeight(28)
+        self.time_slider.setStyleSheet("""
+            QSlider::groove:horizontal {
+                height: 10px;
+                border-radius: 5px;
+                background: #555;
+            }
+            QSlider::handle:horizontal {
+                width: 18px;
+                height: 18px;
+                margin: -4px 0;
+                border-radius: 9px;
+                background: #aaa;
+            }
+            QSlider::handle:horizontal:hover {
+                background: #fff;
+            }
+        """)
+        self.time_slider.valueChanged.connect(self._on_timebar_scrub)
+        bottom_layout.addWidget(self.time_slider, 1)  # stretch=1 fills remaining space
+
+        status_bar.addWidget(bottom_container, 1)
 
     def _toggle_help_box(self):
         from .variable_dock import HelpBox
@@ -453,6 +534,35 @@ class MainWindow(LayoutManagerMixin, QMainWindow):
         multiplier = self.time_unit_combo.currentData()
         self.ctrl_group.set_interval(value / multiplier, None)
 
+    def _on_timebar_scrub(self, value: int) -> None:
+        """Translate a slider integer position to a time and pan all controllers there."""
+        min_time, max_time = self._get_max_min_time()
+        if max_time <= min_time:
+            return
+        t = min_time + (value / _TIMEBAR_RESOLUTION) * (max_time - min_time)
+        self.ctrl_group.set_interval(t, None)
+
+    def _update_timebar(self, min_time: float, max_time: float, current_time: float) -> None:
+        """Update the slider position and view-window band without triggering a scrub event."""
+        if max_time <= min_time:
+            return
+        total = max_time - min_time
+        frac = (current_time - min_time) / total
+        value = int(max(0.0, min(1.0, frac)) * _TIMEBAR_RESOLUTION)
+        self.time_slider.blockSignals(True)
+        self.time_slider.setValue(value)
+        self.time_slider.blockSignals(False)
+
+        # Update the view-window band from the first available controller xlim
+        for ctrl in self.ctrl_group._controller_group.values():
+            if hasattr(ctrl, "get_xlim"):
+                xmin, xmax = ctrl.get_xlim()
+                self.time_slider.set_view_window(
+                    (xmin - min_time) / total,
+                    (xmax - min_time) / total,
+                )
+                break
+
     def _update_time_label(self, current_time):
         time_multiplier = self.time_unit_combo.currentData()
         self.time_spin_box.blockSignals(True)
@@ -460,6 +570,7 @@ class MainWindow(LayoutManagerMixin, QMainWindow):
         if max_time != -float("inf") and min_time != float("inf"):
             self.time_spin_box.setMinimum(min_time * time_multiplier)
             self.time_spin_box.setMaximum(max_time * time_multiplier)
+            self._update_timebar(min_time, max_time, current_time)
         self.time_spin_box.setValue(time_multiplier * current_time)
         self.time_spin_box.blockSignals(False)
 
@@ -604,6 +715,7 @@ class MainWindow(LayoutManagerMixin, QMainWindow):
             time_multiplier = self.time_unit_combo.currentData()
             self.time_spin_box.setMinimum(min_time * time_multiplier)
             self.time_spin_box.setMaximum(max_time * time_multiplier)
+            self._update_timebar(min_time, max_time, self.ctrl_group.current_time)
 
         return dock
 

--- a/src/pynaviz/qt/mainwindow.py
+++ b/src/pynaviz/qt/mainwindow.py
@@ -24,6 +24,24 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from ..controller_group import ControllerGroup
+from ..format_profiles import FORMAT_PROFILES
+from .icons import icon_base64
+from .layout_manager import LayoutManagerMixin
+from .references import EphysReference, NWBReference
+from .variable_dock import VariableDock, _get_variable_from_key_path
+from .variable_loader import get_pynapple_variables
+from .widget_plot import (
+    IntervalSetWidget,
+    TsdFrameWidget,
+    TsdTensorWidget,
+    TsdWidget,
+    TsGroupWidget,
+    TsWidget,
+    VideoHandler,
+    VideoWidget,
+)
+
 _TIMEBAR_RESOLUTION = 1_000_000
 
 
@@ -78,24 +96,6 @@ class _TimeSlider(QSlider):
         step = int(ticks * _TIMEBAR_RESOLUTION / 100)  # 1 % of range per tick
         self.setValue(self.value() + step)
         event.accept()
-
-from ..controller_group import ControllerGroup
-from ..format_profiles import FORMAT_PROFILES
-from .icons import icon_base64
-from .layout_manager import LayoutManagerMixin
-from .references import EphysReference, NWBReference
-from .variable_dock import VariableDock, _get_variable_from_key_path
-from .variable_loader import get_pynapple_variables
-from .widget_plot import (
-    IntervalSetWidget,
-    TsdFrameWidget,
-    TsdTensorWidget,
-    TsdWidget,
-    TsGroupWidget,
-    TsWidget,
-    VideoHandler,
-    VideoWidget,
-)
 
 
 def _session_layout_path() -> pathlib.Path:

--- a/tests/test_time_bar.py
+++ b/tests/test_time_bar.py
@@ -1,0 +1,182 @@
+"""Tests for the time bar: _TimeSlider widget and MainWindow scrubber methods."""
+
+import pytest
+from PySide6.QtCore import QPoint, Qt
+from PySide6.QtGui import QWheelEvent
+
+import pynaviz as viz
+from pynaviz.qt.mainwindow import _TIMEBAR_RESOLUTION, _TimeSlider
+
+# ---------------------------------------------------------------------------
+# _TimeSlider
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def slider(qtbot):
+    s = _TimeSlider(Qt.Orientation.Horizontal)
+    s.setRange(0, _TIMEBAR_RESOLUTION)
+    qtbot.addWidget(s)
+    s.show()
+    return s
+
+
+def test_slider_initial_view_window(slider):
+    assert slider._view_start_frac == 0.0
+    assert slider._view_end_frac == 0.0
+
+
+def test_set_view_window_stores_fractions(slider):
+    slider.set_view_window(0.2, 0.8)
+    assert slider._view_start_frac == pytest.approx(0.2)
+    assert slider._view_end_frac == pytest.approx(0.8)
+
+
+def test_set_view_window_clamps_below_zero(slider):
+    slider.set_view_window(-0.5, 0.3)
+    assert slider._view_start_frac == 0.0
+    assert slider._view_end_frac == pytest.approx(0.3)
+
+
+def test_set_view_window_clamps_above_one(slider):
+    slider.set_view_window(0.7, 1.5)
+    assert slider._view_start_frac == pytest.approx(0.7)
+    assert slider._view_end_frac == 1.0
+
+
+def test_set_view_window_clamps_both_ends(slider):
+    slider.set_view_window(-1.0, 2.0)
+    assert slider._view_start_frac == 0.0
+    assert slider._view_end_frac == 1.0
+
+
+def test_wheel_event_increases_value(slider, qtbot):
+    slider.setValue(500_000)
+    event = QWheelEvent(
+        slider.rect().center().toPointF(),
+        slider.mapToGlobal(slider.rect().center()).toPointF(),
+        QPoint(0, 0),
+        QPoint(0, 120),  # one positive tick
+        Qt.MouseButton.NoButton,
+        Qt.KeyboardModifier.NoModifier,
+        Qt.ScrollPhase.NoScrollPhase,
+        False,
+    )
+    initial = slider.value()
+    slider.wheelEvent(event)
+    assert slider.value() > initial
+
+
+def test_wheel_event_decreases_value(slider, qtbot):
+    slider.setValue(500_000)
+    event = QWheelEvent(
+        slider.rect().center().toPointF(),
+        slider.mapToGlobal(slider.rect().center()).toPointF(),
+        QPoint(0, 0),
+        QPoint(0, -120),  # one negative tick
+        Qt.MouseButton.NoButton,
+        Qt.KeyboardModifier.NoModifier,
+        Qt.ScrollPhase.NoScrollPhase,
+        False,
+    )
+    initial = slider.value()
+    slider.wheelEvent(event)
+    assert slider.value() < initial
+
+
+def test_wheel_event_step_size(slider):
+    """One scroll tick should move the value by 1 % of the full range."""
+    slider.setValue(500_000)
+    event = QWheelEvent(
+        slider.rect().center().toPointF(),
+        slider.mapToGlobal(slider.rect().center()).toPointF(),
+        QPoint(0, 0),
+        QPoint(0, 120),
+        Qt.MouseButton.NoButton,
+        Qt.KeyboardModifier.NoModifier,
+        Qt.ScrollPhase.NoScrollPhase,
+        False,
+    )
+    slider.wheelEvent(event)
+    expected_step = int(1 * _TIMEBAR_RESOLUTION / 100)
+    assert slider.value() == 500_000 + expected_step
+
+
+# ---------------------------------------------------------------------------
+# MainWindow time bar integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def main_window(nap_var, qtbot):
+    mw = viz.qt.mainwindow.MainWindow(nap_var)
+    qtbot.addWidget(mw)
+    for name, var in nap_var.items():
+        mw.add_dock_widget(var, [name])
+    return mw
+
+
+def test_timebar_range(main_window):
+    assert main_window.time_slider.minimum() == 0
+    assert main_window.time_slider.maximum() == _TIMEBAR_RESOLUTION
+
+
+def test_update_timebar_sets_slider_position(main_window):
+    """Slider moves to the correct fractional position."""
+    min_t, max_t = 0.0, 10.0
+    current_t = 5.0  # midpoint → slider should be at 50 %
+    main_window._update_timebar(min_t, max_t, current_t)
+    expected = int(0.5 * _TIMEBAR_RESOLUTION)
+    assert main_window.time_slider.value() == expected
+
+
+def test_update_timebar_at_start(main_window):
+    main_window._update_timebar(0.0, 10.0, 0.0)
+    assert main_window.time_slider.value() == 0
+
+
+def test_update_timebar_at_end(main_window):
+    main_window._update_timebar(0.0, 10.0, 10.0)
+    assert main_window.time_slider.value() == _TIMEBAR_RESOLUTION
+
+
+def test_update_timebar_clamps_out_of_range(main_window):
+    """Values outside [min, max] should be clamped to the slider bounds."""
+    main_window._update_timebar(0.0, 10.0, -5.0)
+    assert main_window.time_slider.value() == 0
+
+    main_window._update_timebar(0.0, 10.0, 20.0)
+    assert main_window.time_slider.value() == _TIMEBAR_RESOLUTION
+
+
+def test_update_timebar_noop_when_range_invalid(main_window):
+    """_update_timebar with max <= min should not change the slider value."""
+    main_window.time_slider.setValue(12345)
+    main_window._update_timebar(5.0, 5.0, 5.0)
+    assert main_window.time_slider.value() == 12345
+
+
+def test_on_timebar_scrub_sets_time(main_window):
+    """Scrubbing to mid-slider should seek to the midpoint of the data range."""
+    min_t, max_t = main_window._get_max_min_time()
+    mid_value = _TIMEBAR_RESOLUTION // 2
+    main_window._on_timebar_scrub(mid_value)
+    expected_t = min_t + 0.5 * (max_t - min_t)
+    assert main_window.ctrl_group.current_time == pytest.approx(expected_t, abs=1e-3)
+
+
+def test_unit_change_updates_spinbox(main_window):
+    """Switching from seconds to milliseconds should multiply the displayed value."""
+    main_window.ctrl_group.set_interval(1.0, None)
+    # Switch to ms unit first, then update the label (which refreshes min/max + value).
+    main_window.time_unit_combo.setCurrentIndex(1)  # ms → multiplier 1e3
+    main_window._update_time_label(1.0)
+    displayed = main_window.time_spin_box.value()
+    assert displayed == pytest.approx(1000.0, rel=1e-3)
+
+
+def test_spinbox_change_seeks_time(main_window):
+    """Typing a value in the spinbox (in seconds) should update the controller time."""
+    main_window.time_unit_combo.setCurrentIndex(2)  # seconds
+    main_window._on_spinbox_changed(3.0)
+    assert main_window.ctrl_group.current_time == pytest.approx(3.0, abs=1e-6)


### PR DESCRIPTION
This pull request adds a new interactive time bar (scrubber) to the application's main window, improving timeline navigation and visualization. The time bar allows users to scrub through time, visually indicates the current view window, and synchronizes with other time controls. Additional integration and code clean-up have been performed for a more intuitive user experience.

**Time Bar (Scrubber) Feature:**

* Added a custom `_TimeSlider` class to provide a horizontal slider with click-to-seek, mouse wheel, and a shaded band indicating the visible time window. (`src/pynaviz/qt/mainwindow.py`)
* Integrated the new time bar into the status bar layout, styled for clarity, and connected its value changes to update the displayed time interval. (`src/pynaviz/qt/mainwindow.py`)
* Implemented `_on_timebar_scrub` and `_update_timebar` methods to synchronize the slider with the application's time state and view window. (`src/pynaviz/qt/mainwindow.py`)
* Ensured the time bar updates whenever the time label or time range changes, keeping all controls in sync. (`src/pynaviz/qt/mainwindow.py`) [[1]](diffhunk://#diff-add46207108b7bdfb55ac949247df9909366779be155c017ace015fb3d55bb6eR537-R573) [[2]](diffhunk://#diff-add46207108b7bdfb55ac949247df9909366779be155c017ace015fb3d55bb6eR718)

**Other Improvements:**

* Updated the `scope` function in `main.py` to explicitly set the global variables, and enabled video handling for improved example usage. (`main.py`) [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L43-R44) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L54-R54)
* Added necessary imports for new Qt classes used in the time bar implementation. (`src/pynaviz/qt/mainwindow.py`)